### PR TITLE
Add github action for coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,30 @@
+name: coverage
+on:
+  pull_request:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-go@v3
+      with:
+        go-version: "1.20"
+    - uses: actions/checkout@v3
+    - run: go test -coverprofile=profile.cov ./...
+    - name: Send coverage
+      uses: shogo82148/actions-goveralls@v1
+      with:
+        path-to-profile: profile.cov
+        parallel: true
+
+  # notifies that all test jobs are finished.
+  finish:
+    needs: coverage
+    runs-on: ubuntu-latest
+    steps:
+    - uses: shogo82148/actions-goveralls@v1
+      with:
+        parallel-finished: true


### PR DESCRIPTION
This change adds a github action to generate coverage profile before reporting to coveralls.io

This is based on the template from https://github.com/m-lab/msak/blob/main/.github/workflows/coverage.yml and https://github.com/marketplace/actions/actions-goveralls

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/3)
<!-- Reviewable:end -->
