### PR TITLE
Add Lookup handler implementation

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: "1.20"
     - uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,10 +9,10 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
         go-version: "1.20"
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: go test -coverprofile=profile.cov ./...
     - name: Send coverage
       uses: shogo82148/actions-goveralls@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,10 +9,10 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
         go-version: "1.20"
-    - uses: actions/checkout@v4
     - run: go test -coverprofile=profile.cov ./...
     - name: Send coverage
       uses: shogo82148/actions-goveralls@v1

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -14,6 +14,7 @@ type Server struct {
 	Iata    IataFinder
 }
 
+// IataFinder is an interface used by the Server to manage IATA information.
 type IataFinder interface {
 	Lookup(country string, lat, lon float64) (string, error)
 	Load(ctx context.Context) error
@@ -27,6 +28,7 @@ func NewServer(project string, finder IataFinder) *Server {
 	}
 }
 
+// Reload reloads all resources used by the Server.
 func (s *Server) Reload(ctx context.Context) {
 	s.Iata.Load(ctx)
 }
@@ -76,7 +78,7 @@ func rawCountry(req *http.Request) string {
 	if c != "" {
 		return c
 	}
-	c = req.URL.Query().Get("X-AppEngine-Country")
+	c = req.Header.Get("X-AppEngine-Country")
 	if c != "" {
 		return c
 	}
@@ -90,7 +92,7 @@ func rawLatLon(req *http.Request) (string, string) {
 	if lat != "" && lon != "" {
 		return lat, lon
 	}
-	latlon := req.URL.Query().Get("X-AppEngine-CityLatLong")
+	latlon := req.Header.Get("X-AppEngine-CityLatLong")
 	if latlon == "0.000000,0.000000" {
 		// TODO: lookup with request IP.
 		return "", ""

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -1,25 +1,59 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 )
 
 // Server maintains shared state for the server.
 type Server struct {
 	Project string
+	Iata    IataFinder
+}
+
+type IataFinder interface {
+	Lookup(country string, lat, lon float64) (string, error)
+	Load(ctx context.Context) error
 }
 
 // NewServer creates a new Server instance for request handling.
-func NewServer(project string) *Server {
+func NewServer(project string, finder IataFinder) *Server {
 	return &Server{
 		Project: project,
+		Iata:    finder,
 	}
+}
+
+func (s *Server) Reload(ctx context.Context) {
+	s.Iata.Load(ctx)
 }
 
 // Lookup is a handler used to find the nearest IATA given client IP or lat/lon metadata.
 func (s *Server) Lookup(rw http.ResponseWriter, req *http.Request) {
-	fmt.Fprintf(rw, "TODO(soltesz): complete lookup logic\n")
+	country := rawCountry(req)
+	if country == "" {
+		rw.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(rw, "could not determine country")
+		return
+	}
+	rlat, rlon := rawLatLon(req)
+	lat, errLat := strconv.ParseFloat(rlat, 64)
+	lon, errLon := strconv.ParseFloat(rlon, 64)
+	if errLat != nil || errLon != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(rw, "could not determine lat/lon")
+		return
+	}
+	code, err := s.Iata.Lookup(country, lat, lon)
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(rw, "could not determine iata code: %v", err)
+		return
+	}
+	fmt.Fprintf(rw, "%s\n", code)
 }
 
 // Register is a handler used by autonodes to register with M-Lab on startup.
@@ -35,4 +69,36 @@ func (s *Server) Live(rw http.ResponseWriter, req *http.Request) {
 // Ready reports whether the server is ready.
 func (s *Server) Ready(rw http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(rw, "ok")
+}
+
+func rawCountry(req *http.Request) string {
+	c := req.URL.Query().Get("country")
+	if c != "" {
+		return c
+	}
+	c = req.URL.Query().Get("X-AppEngine-Country")
+	if c != "" {
+		return c
+	}
+	// TODO: lookup with request IP.
+	return ""
+}
+
+func rawLatLon(req *http.Request) (string, string) {
+	lat := req.URL.Query().Get("lat")
+	lon := req.URL.Query().Get("lon")
+	if lat != "" && lon != "" {
+		return lat, lon
+	}
+	latlon := req.URL.Query().Get("X-AppEngine-CityLatLong")
+	if latlon == "0.000000,0.000000" {
+		// TODO: lookup with request IP.
+		return "", ""
+	}
+	fields := strings.Split(latlon, ",")
+	if len(fields) == 2 {
+		return fields[0], fields[1]
+	}
+	// TODO: lookup with request IP.
+	return "", ""
 }

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -1,0 +1,122 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type fakeIataFinder struct {
+	iata  string
+	err   error
+	loads int
+}
+
+func (f *fakeIataFinder) Lookup(country string, lat, lon float64) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.iata, nil
+}
+func (f *fakeIataFinder) Load(ctx context.Context) error {
+	f.loads++
+	return nil
+}
+
+func TestServer_Lookup(t *testing.T) {
+	tests := []struct {
+		name     string
+		project  string
+		iata     *fakeIataFinder
+		request  string
+		headers  map[string]string
+		wantCode int
+		wantIata string
+	}{
+		{
+			name:     "success-parameters",
+			iata:     &fakeIataFinder{iata: "jfk"},
+			request:  "?country=US&lat=43&lon=-70",
+			wantCode: http.StatusOK,
+			wantIata: "jfk",
+		},
+		{
+			name:     "no-country",
+			iata:     &fakeIataFinder{iata: "jfk"},
+			request:  "?lat=43&lon=-70",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "bad-lat-lon",
+			iata:     &fakeIataFinder{iata: "jfk"},
+			request:  "?country=US&lat=ten&lon=twelve",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "error-lookup",
+			iata:     &fakeIataFinder{err: errors.New("fake error")},
+			request:  "?country=US&lat=43&lon=-70",
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name: "success-headers",
+			iata: &fakeIataFinder{iata: "jfk"},
+			headers: map[string]string{
+				"X-AppEngine-Country":     "US",
+				"X-AppEngine-CityLatLong": "43,-73",
+			},
+			wantCode: http.StatusOK,
+			wantIata: "jfk",
+		},
+		{
+			name: "error-bad-latlon-headers",
+			iata: &fakeIataFinder{iata: "jfk"},
+			headers: map[string]string{
+				"X-AppEngine-Country":     "US",
+				"X-AppEngine-CityLatLong": "xx,zz,yy",
+			},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "error-unknown-latlon-headers",
+			iata: &fakeIataFinder{iata: "jfk"},
+			headers: map[string]string{
+				"X-AppEngine-Country":     "US",
+				"X-AppEngine-CityLatLong": "0.000000,0.000000",
+			},
+			wantCode: http.StatusBadRequest,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewServer(tt.project, tt.iata)
+			rw := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/autojoin/v0/lookup"+tt.request, nil)
+			for key, value := range tt.headers {
+				req.Header.Set(key, value)
+			}
+			s.Lookup(rw, req)
+			if rw.Code != tt.wantCode {
+				t.Errorf("Lookup() returned wrong code; got %d, want %d", rw.Code, tt.wantCode)
+			}
+			resp := strings.Trim(rw.Body.String(), "\n")
+			if rw.Code == http.StatusOK && resp != tt.wantIata {
+				t.Errorf("Lookup() returned wrong iata; got %s, want %s", resp, tt.wantIata)
+			}
+		})
+	}
+}
+
+func TestServer_Reload(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		f := &fakeIataFinder{}
+		s := NewServer("fake", f)
+		s.Reload(context.Background())
+		if f.loads != 1 {
+			t.Errorf("Reload failed to call iata loader")
+		}
+	})
+}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -120,3 +120,17 @@ func TestServer_Reload(t *testing.T) {
 		}
 	})
 }
+
+func TestServer_LiveAndReady(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		f := &fakeIataFinder{}
+		s := NewServer("fake", f)
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		s.Live(rw, req)
+		s.Ready(rw, req)
+
+		// TODO: remove once handler has a real implementation.
+		s.Register(rw, req)
+	})
+}


### PR DESCRIPTION
This change provides a basic implementation for handler Server.Lookup. This is a user-facing interface to help operators identify the correct IATA for a given site.

```sh
$ curl `https://autojoin-dot-mlab-sandbox.appspot.com/autojoin/v0/lookup`
cdw

$ curl 'https://autojoin-dot-mlab-sandbox.appspot.com/autojoin/v0/lookup?lat=40.76&lon=-73.86'
lga
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/4)
<!-- Reviewable:end -->
