### PR TITLE
Add basic support for autojoin/v0/node/register

### DIFF
--- a/api/v0/api.go
+++ b/api/v0/api.go
@@ -1,0 +1,37 @@
+package v0
+
+import (
+	v2 "github.com/m-lab/locate/api/v2"
+	"github.com/m-lab/uuid-annotator/annotator"
+)
+
+// RegisterResponse is returned by a successful.
+type RegisterResponse struct {
+	Error        *v2.Error `json:"error,omitempty"`
+	Registration *Registration
+}
+
+// Network contains IPv4 and IPv6 addresses.
+type Network struct {
+	IPv4 string
+	IPv6 string
+}
+
+// ServerAnnotation is a record used by the uuid-annotator.
+// From: https://github.com/m-lab/uuid-annotator/blob/main/siteannotator/server.go#L83-L90
+type ServerAnnotation struct {
+	Annotation annotator.ServerAnnotations
+	Network    Network
+	Type       string
+}
+
+// Registration is returned for a successful registration request.
+type Registration struct {
+	// Hostname is the dynamic DNS name. Hostname should be available immediately.
+	Hostname string
+
+	// Server is the annotation record used by the uuid-annotator for all server annotations.
+	Server *ServerAnnotation `json:",omitempty"`
+	// Heartbeat is the registration message used by the heartbeat service to register with Locate API.
+	Heartbeat *v2.Registration `json:",omitempty"`
+}

--- a/app.yaml
+++ b/app.yaml
@@ -30,4 +30,6 @@ readiness_check:
   app_start_timeout_sec: 300
 
 env_variables:
+  MAXMIND_URL: gs://downloader-{{PROJECT_ID}}/Maxmind/current/GeoLite2-City.tar.gz
+  ROUTEVIEW_V4_URL: gs://downloader-{{PROJECT_ID}}/RouteViewIPv4/current/routeview.pfx2as.gz
   PROMETHEUSX_LISTEN_ADDRESS: ':9090' # Must match one of the forwarded_ports above.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,4 +18,5 @@ steps:
 # Deployment of APIs in sandbox & staging.
 - name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1
   args:
+  - sed -i -e 's/{{PROJECT_ID}}/$PROJECT_ID/g' app.yaml
   - gcloud --project $PROJECT_ID app deploy --promote app.yaml

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -2,11 +2,18 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	v0 "github.com/m-lab/autojoin/api/v0"
+	"github.com/m-lab/go/testingx"
+	"github.com/m-lab/uuid-annotator/annotator"
+	"github.com/oschwald/geoip2-golang"
 )
 
 type fakeIataFinder struct {
@@ -25,6 +32,27 @@ func (f *fakeIataFinder) Load(ctx context.Context) error {
 	f.loads++
 	return nil
 }
+
+type fakeMaxmind struct {
+	city *geoip2.City
+	err  error
+}
+
+func (f *fakeMaxmind) City(ip net.IP) (*geoip2.City, error) {
+	return f.city, f.err
+}
+func (f *fakeMaxmind) Reload(ctx context.Context) error {
+	return nil
+}
+
+type fakeAsn struct {
+	ann *annotator.Network
+}
+
+func (f *fakeAsn) AnnotateIP(src string) *annotator.Network {
+	return f.ann
+}
+func (f *fakeAsn) Reload(ctx context.Context) {}
 
 func TestServer_Lookup(t *testing.T) {
 	tests := []struct {
@@ -92,7 +120,7 @@ func TestServer_Lookup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewServer(tt.project, tt.iata)
+			s := NewServer(tt.project, tt.iata, &fakeMaxmind{}, &fakeAsn{})
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/autojoin/v0/lookup"+tt.request, nil)
 			for key, value := range tt.headers {
@@ -113,7 +141,7 @@ func TestServer_Lookup(t *testing.T) {
 func TestServer_Reload(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		f := &fakeIataFinder{}
-		s := NewServer("fake", f)
+		s := NewServer("fake", f, &fakeMaxmind{}, &fakeAsn{})
 		s.Reload(context.Background())
 		if f.loads != 1 {
 			t.Errorf("Reload failed to call iata loader")
@@ -124,13 +152,109 @@ func TestServer_Reload(t *testing.T) {
 func TestServer_LiveAndReady(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		f := &fakeIataFinder{}
-		s := NewServer("fake", f)
+		s := NewServer("fake", f, &fakeMaxmind{}, &fakeAsn{})
 		rw := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		s.Live(rw, req)
 		s.Ready(rw, req)
-
-		// TODO: remove once handler has a real implementation.
-		s.Register(rw, req)
 	})
+}
+
+func TestServer_Register(t *testing.T) {
+	tests := []struct {
+		name     string
+		Project  string
+		Iata     IataFinder
+		Maxmind  MaxmindFinder
+		ASN      ASNFinder
+		params   string
+		wantName string
+		wantCode int
+	}{
+		{
+			name:   "success",
+			params: "?service=foo&organization=bar&iata=lga&ip=192.168.0.1",
+			ASN: &fakeAsn{
+				ann: &annotator.Network{
+					ASNumber: 12345,
+				},
+			},
+			wantName: "foo-lga12345-c0a80001.bar.autojoin.measurement-lab.org",
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "error-bad-service",
+			params:   "?service=-BAD-NAME-",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "error-bad-organization",
+			params:   "?service=foo&organization=-BAD-NAME-",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "error-bad-ip",
+			params:   "?service=foo&organization=bar&ip=-BAD-IP-",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "error-bad-iata",
+			Iata: &fakeIataFinder{err: errors.New("bad lookup")},
+			Maxmind: &fakeMaxmind{
+				err: errors.New("bad lookup"),
+			},
+			/*
+					city: &geoip2.City{
+						Country: struct {
+							GeoNameID         uint              `maxminddb:"geoname_id"`
+							IsInEuropeanUnion bool              `maxminddb:"is_in_european_union"`
+							IsoCode           string            `maxminddb:"iso_code"`
+							Names             map[string]string `maxminddb:"names"`
+						}{
+							IsoCode: "US",
+						},
+						Location: struct {
+							AccuracyRadius uint16  `maxminddb:"accuracy_radius"`
+							Latitude       float64 `maxminddb:"latitude"`
+							Longitude      float64 `maxminddb:"longitude"`
+							MetroCode      uint    `maxminddb:"metro_code"`
+							TimeZone       string  `maxminddb:"time_zone"`
+						}{
+							Latitude:  41,
+							Longitude: -73,
+						},
+					},
+				},
+			*/
+			params:   "?service=foo&organization=bar&ip=192.168.0.1&iata=-invalid-",
+			wantCode: http.StatusBadRequest,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewServer("fake", tt.Iata, tt.Maxmind, tt.ASN)
+			rw := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/autojoin/v0/node/register"+tt.params, nil)
+
+			s.Register(rw, req)
+
+			if rw.Code != tt.wantCode {
+				t.Errorf("Register() returned wrong code; got %d, want %d", rw.Code, tt.wantCode)
+			}
+			if rw.Code != http.StatusOK {
+				return
+			}
+
+			// Check response content.
+			resp := v0.RegisterResponse{}
+			raw := rw.Body.Bytes()
+			err := json.Unmarshal(raw, &resp)
+			testingx.Must(t, err, "failed to unmarshal response")
+
+			if resp.Registration.Hostname != tt.wantName {
+				t.Errorf("Register() returned wrong hostname; got %s, want %s", resp.Registration.Hostname, tt.wantName)
+			}
+
+		})
+	}
 }

--- a/iata/lookup.go
+++ b/iata/lookup.go
@@ -127,3 +127,19 @@ func (c *Client) Lookup(country string, lat, lon float64) (string, error) {
 	// Return closest.
 	return airports[0].iata, nil
 }
+
+// Find returns the row with metadata about the given iata code.
+func (c *Client) Find(iata string) (Row, error) {
+	c.mu.Lock()
+	// Allow safe Load during Lookup.
+	rows := c.rows
+	c.mu.Unlock()
+	// Find all distances to airports in country.
+	for i := range rows {
+		r := rows[i]
+		if r.IATA == iata {
+			return r, nil
+		}
+	}
+	return Row{}, ErrNoAirports
+}

--- a/internal/maxmind/maxmind.go
+++ b/internal/maxmind/maxmind.go
@@ -11,18 +11,17 @@ import (
 	"github.com/m-lab/uuid-annotator/tarreader"
 )
 
-// Maxmind manages access to the maxmind database.
+// NewMaxmindManger creates a new MaxmindManager and loads Maxmind data from the
+// given content.Provider.
+func NewMaxmind(src content.Provider) *Maxmind {
+	return &Maxmind{src: src}
+}
+
+// MaxmindManager manages access to the maxmind database.
 type Maxmind struct {
 	mu      sync.RWMutex
 	src     content.Provider
 	Maxmind *geoip2.Reader
-}
-
-// NewMaxmind creates a new Maxmind instance which loads data from the given
-// content.Provider. Callers must call Reload() at least once on the returned
-// Maxmind instance before calling City().
-func NewMaxmind(src content.Provider) *Maxmind {
-	return &Maxmind{src: src}
 }
 
 // City searches for metadata associated with the given IP.

--- a/internal/maxmind/maxmind.go
+++ b/internal/maxmind/maxmind.go
@@ -11,17 +11,18 @@ import (
 	"github.com/m-lab/uuid-annotator/tarreader"
 )
 
-// NewMaxmindManger creates a new MaxmindManager and loads Maxmind data from the
-// given content.Provider.
-func NewMaxmind(src content.Provider) *Maxmind {
-	return &Maxmind{src: src}
-}
-
-// MaxmindManager manages access to the maxmind database.
+// Maxmind manages access to the maxmind database.
 type Maxmind struct {
 	mu      sync.RWMutex
 	src     content.Provider
 	Maxmind *geoip2.Reader
+}
+
+// NewMaxmind creates a new Maxmind instance which loads data from the given
+// content.Provider. Callers must call Reload() at least once on the returned
+// Maxmind instance before calling City().
+func NewMaxmind(src content.Provider) *Maxmind {
+	return &Maxmind{src: src}
 }
 
 // City searches for metadata associated with the given IP.


### PR DESCRIPTION
This change adds basic support for node registration. This includes defining v0 response structures as well as dependencies on loading Maxmind and ip2prefix ASN datasets needed to calculate a hostname. The hostname is not registered in DNS as part of this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/6)
<!-- Reviewable:end -->
