### PR TITLE
Add api definition for Lookup and Register responses

### DIFF
--- a/api/v0/api.go
+++ b/api/v0/api.go
@@ -1,0 +1,48 @@
+package v0
+
+import (
+	v2 "github.com/m-lab/locate/api/v2"
+	"github.com/m-lab/uuid-annotator/annotator"
+)
+
+// LookupResponse is returned by a lookup request.
+type LookupResponse struct {
+	Error  *v2.Error `json:",omitempty"`
+	Lookup *Lookup   `json:",omitempty"`
+}
+
+// Lookup is returned for a successful lookup request.
+type Lookup struct {
+	IATA string
+}
+
+// RegisterResponse is returned by a register request.
+type RegisterResponse struct {
+	Error        *v2.Error     `json:",omitempty"`
+	Registration *Registration `json:",omitempty"`
+}
+
+// Network contains IPv4 and IPv6 addresses.
+type Network struct {
+	IPv4 string
+	IPv6 string
+}
+
+// ServerAnnotation is used by the uuid-annotator.
+// From: https://github.com/m-lab/uuid-annotator/blob/main/siteannotator/server.go#L83-L90
+type ServerAnnotation struct {
+	Annotation annotator.ServerAnnotations
+	Network    Network
+	Type       string
+}
+
+// Registration is returned for a successful registration request.
+type Registration struct {
+	// Hostname is the dynamic DNS name. Hostname should be available immediately.
+	Hostname string
+
+	// Annotation is the metadata used by the uuid-annotator for all server annotations.
+	Annotation *ServerAnnotation `json:",omitempty"`
+	// Heartbeat is the registration message used by the heartbeat service to register with the Locate API.
+	Heartbeat *v2.Registration `json:",omitempty"`
+}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	v0 "github.com/m-lab/autojoin/api/v0"
+	"github.com/m-lab/go/rtx"
 	v2 "github.com/m-lab/locate/api/v2"
 )
 
@@ -130,9 +131,9 @@ func rawLatLon(req *http.Request) (string, string) {
 
 func writeResponse(rw http.ResponseWriter, resp interface{}) error {
 	b, err := json.MarshalIndent(resp, "", "  ")
-	if err != nil {
-		return err
-	}
+	// NOTE: marshal can only fail on incompatible types, like functions. The
+	// panic will be caught by the http server handler.
+	rtx.PanicOnError(err, "failed to marshal response")
 	rw.Write(b)
 	return nil
 }

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -2,11 +2,14 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
+
+	v0 "github.com/m-lab/autojoin/api/v0"
+	"github.com/m-lab/go/testingx"
 )
 
 type fakeIataFinder struct {
@@ -102,9 +105,10 @@ func TestServer_Lookup(t *testing.T) {
 			if rw.Code != tt.wantCode {
 				t.Errorf("Lookup() returned wrong code; got %d, want %d", rw.Code, tt.wantCode)
 			}
-			resp := strings.Trim(rw.Body.String(), "\n")
-			if rw.Code == http.StatusOK && resp != tt.wantIata {
-				t.Errorf("Lookup() returned wrong iata; got %s, want %s", resp, tt.wantIata)
+			resp := &v0.LookupResponse{}
+			testingx.Must(t, json.Unmarshal(rw.Body.Bytes(), resp), "failed to parse response")
+			if rw.Code == http.StatusOK && resp.Lookup != nil && resp.Lookup.IATA != tt.wantIata {
+				t.Errorf("Lookup() returned wrong iata; got %#v, want %s", resp, tt.wantIata)
 			}
 		})
 	}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -107,7 +107,7 @@ func TestServer_Lookup(t *testing.T) {
 			}
 			resp := &v0.LookupResponse{}
 			testingx.Must(t, json.Unmarshal(rw.Body.Bytes(), resp), "failed to parse response")
-			if rw.Code == http.StatusOK && resp.Lookup != nil && resp.Lookup.IATA != tt.wantIata {
+			if rw.Code == http.StatusOK && (resp.Lookup == nil || resp.Lookup.IATA != tt.wantIata) {
 				t.Errorf("Lookup() returned wrong iata; got %#v, want %s", resp, tt.wantIata)
 			}
 		})


### PR DESCRIPTION
This change introduces the api/v0 type definitions for the autojoin API, including the `LookupResponse` and planned `RegisterResponse` structs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/7)
<!-- Reviewable:end -->
