### PR TITLE
Add "ErrNotFound" to maxmind package and "Find" method for iata metadata

### DIFF
--- a/iata/lookup.go
+++ b/iata/lookup.go
@@ -135,7 +135,8 @@ func (c *Client) Find(iata string) (Row, error) {
 	rows := c.rows
 	c.mu.Unlock()
 	iata = strings.ToLower(iata)
-	// Find all distances to airports in country.
+	// Check each known airport for the given one.
+	// Note: this is a linear search since airports are not in a guaranteed order.
 	for i := range rows {
 		r := rows[i]
 		if r.IATA == iata {

--- a/iata/lookup.go
+++ b/iata/lookup.go
@@ -127,3 +127,20 @@ func (c *Client) Lookup(country string, lat, lon float64) (string, error) {
 	// Return closest.
 	return airports[0].iata, nil
 }
+
+// Find returns the row with metadata about the given iata code.
+func (c *Client) Find(iata string) (Row, error) {
+	c.mu.Lock()
+	// Allow safe Load during Lookup.
+	rows := c.rows
+	c.mu.Unlock()
+	iata = strings.ToLower(iata)
+	// Find all distances to airports in country.
+	for i := range rows {
+		r := rows[i]
+		if r.IATA == iata {
+			return r, nil
+		}
+	}
+	return Row{}, ErrNoAirports
+}

--- a/internal/maxmind/maxmind.go
+++ b/internal/maxmind/maxmind.go
@@ -42,7 +42,7 @@ func (mm *Maxmind) City(ip net.IP) (*geoip2.City, error) {
 	if isEmpty(record) {
 		return nil, ErrNotFound
 	}
-	return mm.Maxmind.City(ip)
+	return record, nil
 }
 
 func isEmpty(r *geoip2.City) bool {

--- a/internal/maxmind/maxmind_test.go
+++ b/internal/maxmind/maxmind_test.go
@@ -80,6 +80,12 @@ func TestMaxmind_City(t *testing.T) {
 			ip:      net.IP([]byte{0, 0}), // invalid/corrup input IP.
 			wantErr: true,
 		},
+		{
+			name:    "error-empty-result",
+			src:     "file:testdata/fake-geolite2.tar.gz",
+			ip:      net.ParseIP("192.168.0.1"), // private ip not found in data.
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR updates two existing interfaces to help implement the Register logic (still pending). As a result of this change:
* the Maxmind.City method can return `ErrNotFound` error rather than an empty record.
* the iata.Client includes a new method to `Find` metadata based on the iata name.

The iata dataset will be the authoritative source for latitude and longitude information, and a required parameter to the `Register` operation. The `Find` method will allow to lookup the latitude & longitude metadata for a chosen iata to associate this location with the server's annotation and heartbeat data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/8)
<!-- Reviewable:end -->
