### PR TITLE
Add maxmind to Lookup

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -31,3 +31,4 @@ readiness_check:
 
 env_variables:
   PROMETHEUSX_LISTEN_ADDRESS: ':9090' # Must match one of the forwarded_ports above.
+  MAXMIND_URL: gs://downloader-{{PROJECT_ID}}/Maxmind/current/GeoLite2-City.tar.gz

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,4 +18,5 @@ steps:
 # Deployment of APIs in sandbox & staging.
 - name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1
   args:
+  - sed -i -e 's/{{PROJECT_ID}}/$PROJECT_ID/g' app.yaml
   - gcloud --project $PROJECT_ID app deploy --promote app.yaml

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -3,7 +3,9 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -11,12 +13,20 @@ import (
 	v0 "github.com/m-lab/autojoin/api/v0"
 	"github.com/m-lab/go/rtx"
 	v2 "github.com/m-lab/locate/api/v2"
+	"github.com/oschwald/geoip2-golang"
 )
 
 // Server maintains shared state for the server.
 type Server struct {
 	Project string
 	Iata    IataFinder
+	Maxmind MaxmindFinder
+}
+
+// MaxmindFinder is an interface used by the Server to manage Maxmind information.
+type MaxmindFinder interface {
+	City(ip net.IP) (*geoip2.City, error)
+	Reload(ctx context.Context) error
 }
 
 // IataFinder is an interface used by the Server to manage IATA information.
@@ -26,23 +36,27 @@ type IataFinder interface {
 }
 
 // NewServer creates a new Server instance for request handling.
-func NewServer(project string, finder IataFinder) *Server {
+func NewServer(project string, finder IataFinder, maxmind MaxmindFinder) *Server {
 	return &Server{
 		Project: project,
 		Iata:    finder,
+		Maxmind: maxmind,
 	}
 }
 
 // Reload reloads all resources used by the Server.
 func (s *Server) Reload(ctx context.Context) {
 	s.Iata.Load(ctx)
+	s.Maxmind.Reload(ctx)
+
 }
 
 // Lookup is a handler used to find the nearest IATA given client IP or lat/lon metadata.
 func (s *Server) Lookup(rw http.ResponseWriter, req *http.Request) {
+
 	resp := v0.LookupResponse{}
-	country := rawCountry(req)
-	if country == "" {
+	country, err := s.rawCountry(req)
+	if country == "" || err != nil {
 		resp.Error = &v2.Error{
 			Type:   "?country=<country>",
 			Title:  "could not determine country from request",
@@ -52,10 +66,10 @@ func (s *Server) Lookup(rw http.ResponseWriter, req *http.Request) {
 		writeResponse(rw, resp)
 		return
 	}
-	rlat, rlon := rawLatLon(req)
+	rlat, rlon, err := s.rawLatLon(req)
 	lat, errLat := strconv.ParseFloat(rlat, 64)
 	lon, errLon := strconv.ParseFloat(rlon, 64)
-	if errLat != nil || errLon != nil {
+	if err != nil || errLat != nil || errLon != nil {
 		resp.Error = &v2.Error{
 			Type:   "?lat=<lat>&lon=<lon>",
 			Title:  "could not determine lat/lon from request",
@@ -97,36 +111,50 @@ func (s *Server) Ready(rw http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(rw, "ok")
 }
 
-func rawCountry(req *http.Request) string {
+func (s *Server) rawCountry(req *http.Request) (string, error) {
 	c := req.URL.Query().Get("country")
 	if c != "" {
-		return c
+		return c, nil
 	}
 	c = req.Header.Get("X-AppEngine-Country")
 	if c != "" {
-		return c
+		return c, nil
 	}
-	// TODO: lookup with request IP.
-	return ""
+	rawip, err := rawIPFromRequest(req)
+	// note: an error is practically impossible.
+	rtx.PanicOnError(err, "could not identify any client ip")
+	ip := net.ParseIP(rawip)
+	record, err := s.Maxmind.City(ip)
+	if err != nil {
+		return "", err
+	}
+	return record.Country.IsoCode, nil
 }
 
-func rawLatLon(req *http.Request) (string, string) {
+func (s *Server) rawLatLon(req *http.Request) (string, string, error) {
 	lat := req.URL.Query().Get("lat")
 	lon := req.URL.Query().Get("lon")
 	if lat != "" && lon != "" {
-		return lat, lon
+		return lat, lon, nil
 	}
 	latlon := req.Header.Get("X-AppEngine-CityLatLong")
 	if latlon == "0.000000,0.000000" {
 		// TODO: lookup with request IP.
-		return "", ""
+		return "", "", nil
 	}
 	fields := strings.Split(latlon, ",")
 	if len(fields) == 2 {
-		return fields[0], fields[1]
+		return fields[0], fields[1], nil
 	}
-	// TODO: lookup with request IP.
-	return "", ""
+	rawip, err := rawIPFromRequest(req)
+	// note: an error is practically impossible.
+	rtx.PanicOnError(err, "could not identify any client ip")
+	ip := net.ParseIP(rawip)
+	record, err := s.Maxmind.City(ip)
+	if err != nil {
+		return "", "", err
+	}
+	return fmt.Sprintf("%.5f", record.Location.Latitude), fmt.Sprintf("%.5f", record.Location.Longitude), nil
 }
 
 func writeResponse(rw http.ResponseWriter, resp interface{}) error {
@@ -136,4 +164,25 @@ func writeResponse(rw http.ResponseWriter, resp interface{}) error {
 	rtx.PanicOnError(err, "failed to marshal response")
 	rw.Write(b)
 	return nil
+}
+
+var ErrIPNotFound = errors.New("counld not find ip")
+
+func rawIPFromRequest(req *http.Request) (string, error) {
+	// Use given IP parameter.
+	rawip := req.URL.Query().Get("ipv4")
+	if rawip != "" {
+		return rawip, nil
+	}
+	// Use AppEngine's forwarded client address.
+	fwdIPs := strings.Split(req.Header.Get("X-Forwarded-For"), ", ")
+	if fwdIPs[0] != "" {
+		return fwdIPs[0], nil
+	}
+	// Use remote client address.
+	hip, _, _ := net.SplitHostPort(req.RemoteAddr)
+	//if hip != "" {
+	return hip, nil
+	//}
+	//return "", ErrIPNotFound
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -181,8 +181,5 @@ func rawIPFromRequest(req *http.Request) (string, error) {
 	}
 	// Use remote client address.
 	hip, _, _ := net.SplitHostPort(req.RemoteAddr)
-	//if hip != "" {
 	return hip, nil
-	//}
-	//return "", ErrIPNotFound
 }

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	v0 "github.com/m-lab/autojoin/api/v0"
 	"github.com/m-lab/go/testingx"
+	"github.com/oschwald/geoip2-golang"
 )
 
 type fakeIataFinder struct {
@@ -29,11 +31,23 @@ func (f *fakeIataFinder) Load(ctx context.Context) error {
 	return nil
 }
 
+type fakeMaxmind struct {
+	city *geoip2.City
+	err  error
+}
+
+func (f *fakeMaxmind) City(ip net.IP) (*geoip2.City, error) {
+	return f.city, f.err
+}
+func (f *fakeMaxmind) Reload(ctx context.Context) error {
+	return nil
+}
+
 func TestServer_Lookup(t *testing.T) {
 	tests := []struct {
 		name     string
-		project  string
 		iata     *fakeIataFinder
+		maxmind  *fakeMaxmind
 		request  string
 		headers  map[string]string
 		wantCode int
@@ -49,8 +63,45 @@ func TestServer_Lookup(t *testing.T) {
 		{
 			name:     "no-country",
 			iata:     &fakeIataFinder{iata: "jfk"},
+			maxmind:  &fakeMaxmind{err: errors.New("fake error")},
 			request:  "?lat=43&lon=-70",
 			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "no-country-with-ipv4",
+			iata:     &fakeIataFinder{iata: "jfk"},
+			maxmind:  &fakeMaxmind{err: errors.New("fake error")},
+			request:  "?lat=43&lon=-70&ipv4=192.168.0.1",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:    "no-country-with-ipv4-headers",
+			iata:    &fakeIataFinder{iata: "jfk"},
+			maxmind: &fakeMaxmind{err: errors.New("fake error")},
+			headers: map[string]string{
+				"X-Forwarded-For": "192.168.0.1",
+			},
+			request:  "?lat=43&lon=-70",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "country-from-maxmind",
+			iata: &fakeIataFinder{iata: "jfk"},
+			maxmind: &fakeMaxmind{
+				city: &geoip2.City{
+					Country: struct {
+						GeoNameID         uint              `maxminddb:"geoname_id"`
+						IsInEuropeanUnion bool              `maxminddb:"is_in_european_union"`
+						IsoCode           string            `maxminddb:"iso_code"`
+						Names             map[string]string `maxminddb:"names"`
+					}{
+						IsoCode: "US",
+					},
+				},
+			},
+			request:  "?lat=43&lon=-70",
+			wantIata: "jfk",
+			wantCode: http.StatusOK,
 		},
 		{
 			name:     "bad-lat-lon",
@@ -75,13 +126,38 @@ func TestServer_Lookup(t *testing.T) {
 			wantIata: "jfk",
 		},
 		{
-			name: "error-bad-latlon-headers",
-			iata: &fakeIataFinder{iata: "jfk"},
+			name:    "error-bad-latlon-headers",
+			iata:    &fakeIataFinder{iata: "jfk"},
+			maxmind: &fakeMaxmind{err: ErrIPNotFound},
 			headers: map[string]string{
 				"X-AppEngine-Country":     "US",
 				"X-AppEngine-CityLatLong": "xx,zz,yy",
 			},
 			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "latlon-headers-from-maxmind",
+			iata: &fakeIataFinder{iata: "jfk"},
+			maxmind: &fakeMaxmind{
+				city: &geoip2.City{
+					Location: struct {
+						AccuracyRadius uint16  `maxminddb:"accuracy_radius"`
+						Latitude       float64 `maxminddb:"latitude"`
+						Longitude      float64 `maxminddb:"longitude"`
+						MetroCode      uint    `maxminddb:"metro_code"`
+						TimeZone       string  `maxminddb:"time_zone"`
+					}{
+						Latitude:  40,
+						Longitude: -71,
+					},
+				},
+			},
+			headers: map[string]string{
+				"X-AppEngine-Country":     "US",
+				"X-AppEngine-CityLatLong": "xx,zz,yy",
+			},
+			wantCode: http.StatusOK,
+			wantIata: "jfk",
 		},
 		{
 			name: "error-unknown-latlon-headers",
@@ -95,7 +171,7 @@ func TestServer_Lookup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewServer(tt.project, tt.iata)
+			s := NewServer("mlab-sandbox", tt.iata, tt.maxmind)
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/autojoin/v0/lookup"+tt.request, nil)
 			for key, value := range tt.headers {
@@ -117,7 +193,7 @@ func TestServer_Lookup(t *testing.T) {
 func TestServer_Reload(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		f := &fakeIataFinder{}
-		s := NewServer("fake", f)
+		s := NewServer("mlab-sandbox", f, &fakeMaxmind{})
 		s.Reload(context.Background())
 		if f.loads != 1 {
 			t.Errorf("Reload failed to call iata loader")
@@ -127,8 +203,7 @@ func TestServer_Reload(t *testing.T) {
 
 func TestServer_LiveAndReady(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		f := &fakeIataFinder{}
-		s := NewServer("fake", f)
+		s := NewServer("mlab-sandbox", &fakeIataFinder{}, &fakeMaxmind{})
 		rw := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		s.Live(rw, req)

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -128,7 +128,7 @@ func TestServer_Lookup(t *testing.T) {
 		{
 			name:    "error-bad-latlon-headers",
 			iata:    &fakeIataFinder{iata: "jfk"},
-			maxmind: &fakeMaxmind{err: ErrIPNotFound},
+			maxmind: &fakeMaxmind{err: errors.New("fake error")},
 			headers: map[string]string{
 				"X-AppEngine-Country":     "US",
 				"X-AppEngine-CityLatLong": "xx,zz,yy",
@@ -160,8 +160,9 @@ func TestServer_Lookup(t *testing.T) {
 			wantIata: "jfk",
 		},
 		{
-			name: "error-unknown-latlon-headers",
-			iata: &fakeIataFinder{iata: "jfk"},
+			name:    "error-unknown-latlon-headers",
+			iata:    &fakeIataFinder{iata: "jfk"},
+			maxmind: &fakeMaxmind{err: errors.New("fake error")},
 			headers: map[string]string{
 				"X-AppEngine-Country":     "US",
 				"X-AppEngine-CityLatLong": "0.000000,0.000000",

--- a/internal/maxmind/maxmind.go
+++ b/internal/maxmind/maxmind.go
@@ -42,7 +42,7 @@ func (mm *Maxmind) City(ip net.IP) (*geoip2.City, error) {
 	if isEmpty(record) {
 		return nil, ErrNotFound
 	}
-	return record, nil
+	return mm.Maxmind.City(ip)
 }
 
 func isEmpty(r *geoip2.City) bool {

--- a/internal/maxmind/maxmind.go
+++ b/internal/maxmind/maxmind.go
@@ -42,7 +42,7 @@ func (mm *Maxmind) City(ip net.IP) (*geoip2.City, error) {
 	if isEmpty(record) {
 		return nil, ErrNotFound
 	}
-	return mm.Maxmind.City(ip)
+	return record, nil
 }
 
 func isEmpty(r *geoip2.City) bool {

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func init() {
 	flag.StringVar(&listenPort, "port", "8080", "AppEngine port environment variable")
 	flag.StringVar(&project, "google-cloud-project", "", "AppEngine project environment variable")
 	flag.Var(&iataSrc, "iata-url", "URL to IATA dataset")
-	flag.Var(&maxmindSrc, "maxmind-url", "When -locator-maxmind is true, the tar URL of MaxMind IP database. May be: gs://bucket/file or file:./relativepath/file")
+	flag.Var(&maxmindSrc, "maxmind-url", "URL of a Maxmind GeoIP dataset, e.g. gs://bucket/file or file:./relativepath/file")
 
 	// Enable logging with line numbers to trace error locations.
 	log.SetFlags(log.LUTC | log.Llongfile)

--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/m-lab/autojoin/handler"
 	"github.com/m-lab/autojoin/iata"
+	"github.com/m-lab/autojoin/internal/maxmind"
+	"github.com/m-lab/go/content"
 	"github.com/m-lab/go/flagx"
 	"github.com/m-lab/go/httpx"
 	"github.com/m-lab/go/memoryless"
@@ -23,6 +25,7 @@ var (
 	listenPort string
 	project    string
 	iataSrc    = flagx.MustNewURL("https://raw.githubusercontent.com/ip2location/ip2location-iata-icao/1.0.10/iata-icao.csv")
+	maxmindSrc = flagx.URL{}
 
 	// RequestHandlerDuration is a histogram that tracks the latency of each request handler.
 	RequestHandlerDuration = promauto.NewHistogramVec(
@@ -39,6 +42,7 @@ func init() {
 	flag.StringVar(&listenPort, "port", "8080", "AppEngine port environment variable")
 	flag.StringVar(&project, "google-cloud-project", "", "AppEngine project environment variable")
 	flag.Var(&iataSrc, "iata-url", "URL to IATA dataset")
+	flag.Var(&maxmindSrc, "maxmind-url", "When -locator-maxmind is true, the tar URL of MaxMind IP database. May be: gs://bucket/file or file:./relativepath/file")
 
 	// Enable logging with line numbers to trace error locations.
 	log.SetFlags(log.LUTC | log.Llongfile)
@@ -57,10 +61,15 @@ func main() {
 	i, err := iata.New(mainCtx, iataSrc.URL)
 	rtx.Must(err, "failed to load iata dataset")
 
-	s := handler.NewServer(project, i)
+	mmsrc, err := content.FromURL(mainCtx, maxmindSrc.URL)
+	rtx.Must(err, "failed to load maxmindurl: %s", maxmindSrc.URL)
+	mm := maxmind.NewMaxmind(mmsrc)
+
+	s := handler.NewServer(project, i, mm)
 	go func() {
 		// Load once.
 		s.Iata.Load(mainCtx)
+		s.Maxmind.Reload(mainCtx)
 
 		// Check and reload db at least once a day.
 		reloadConfig := memoryless.Config{
@@ -72,6 +81,7 @@ func main() {
 		rtx.Must(err, "Could not create ticker for reloading")
 		for range tick.C {
 			s.Iata.Load(mainCtx)
+			s.Maxmind.Reload(mainCtx)
 		}
 	}()
 


### PR DESCRIPTION
This change adds support for maxmind to the autojoin server. This change uses the maxmind dataset as a fallback for country and location lookup. The maxmind dataset will also be helpful for finding geographic metadata needed for node registration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/9)
<!-- Reviewable:end -->
