### PR TITLE
Add beginning of Register handler

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -32,3 +32,4 @@ readiness_check:
 env_variables:
   PROMETHEUSX_LISTEN_ADDRESS: ':9090' # Must match one of the forwarded_ports above.
   MAXMIND_URL: gs://downloader-{{PROJECT_ID}}/Maxmind/current/GeoLite2-City.tar.gz
+  ROUTEVIEW_V4_URL: gs://downloader-{{PROJECT_ID}}/RouteViewIPv4/current/routeview.pfx2as.gz

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -7,18 +7,24 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
 	v0 "github.com/m-lab/autojoin/api/v0"
+	"github.com/m-lab/autojoin/iata"
+	"github.com/m-lab/autojoin/internal/register"
 	"github.com/m-lab/go/rtx"
 	v2 "github.com/m-lab/locate/api/v2"
+	"github.com/m-lab/uuid-annotator/annotator"
 	"github.com/oschwald/geoip2-golang"
 )
 
 var (
 	errLocationNotFound = errors.New("location not found")
 	errLocationFormat   = errors.New("location could not be parsed")
+
+	validName = regexp.MustCompile(`[a-z0-9]+`)
 )
 
 // Server maintains shared state for the server.
@@ -26,6 +32,13 @@ type Server struct {
 	Project string
 	Iata    IataFinder
 	Maxmind MaxmindFinder
+	ASN     ASNFinder
+}
+
+// ASNFinder is an interface used by the Server to manage ASN information.
+type ASNFinder interface {
+	AnnotateIP(src string) *annotator.Network
+	Reload(ctx context.Context)
 }
 
 // MaxmindFinder is an interface used by the Server to manage Maxmind information.
@@ -37,15 +50,17 @@ type MaxmindFinder interface {
 // IataFinder is an interface used by the Server to manage IATA information.
 type IataFinder interface {
 	Lookup(country string, lat, lon float64) (string, error)
+	Find(iata string) (iata.Row, error)
 	Load(ctx context.Context) error
 }
 
 // NewServer creates a new Server instance for request handling.
-func NewServer(project string, finder IataFinder, maxmind MaxmindFinder) *Server {
+func NewServer(project string, finder IataFinder, maxmind MaxmindFinder, asn ASNFinder) *Server {
 	return &Server{
 		Project: project,
 		Iata:    finder,
 		Maxmind: maxmind,
+		ASN:     asn,
 	}
 }
 
@@ -57,7 +72,6 @@ func (s *Server) Reload(ctx context.Context) {
 
 // Lookup is a handler used to find the nearest IATA given client IP or lat/lon metadata.
 func (s *Server) Lookup(rw http.ResponseWriter, req *http.Request) {
-
 	resp := v0.LookupResponse{}
 	country, err := s.getCountry(req)
 	if country == "" || err != nil {
@@ -98,9 +112,91 @@ func (s *Server) Lookup(rw http.ResponseWriter, req *http.Request) {
 	writeResponse(rw, resp)
 }
 
-// Register is a handler used by autonodes to register with M-Lab on startup.
+// Register handler is used by autonodes to register their hostname with M-Lab
+// on startup and receive additional needed configuration metadata.
 func (s *Server) Register(rw http.ResponseWriter, req *http.Request) {
-	fmt.Fprintf(rw, "TODO(soltesz): complete register logic\n")
+	resp := v0.RegisterResponse{}
+	param := &register.Params{Project: s.Project}
+	param.Service = req.URL.Query().Get("service")
+	if !isValidName(param.Service) {
+		resp.Error = &v2.Error{
+			Type:   "?service=<service>",
+			Title:  "could not determine service from request",
+			Status: http.StatusBadRequest,
+		}
+		rw.WriteHeader(resp.Error.Status)
+		writeResponse(rw, resp)
+		return
+	}
+	// TODO(soltesz): discover this from a given API key.
+	param.Org = req.URL.Query().Get("organization")
+	if !isValidName(param.Org) {
+		resp.Error = &v2.Error{
+			Type:   "?organization=<organization>",
+			Title:  "could not determine organization from request",
+			Status: http.StatusBadRequest,
+		}
+		rw.WriteHeader(resp.Error.Status)
+		writeResponse(rw, resp)
+		return
+	}
+	// TODO: check value.
+	param.IPv6 = req.URL.Query().Get("ipv6") // optional.
+	param.IPv4 = getClientIP(req)
+	ip := net.ParseIP(param.IPv4)
+	if ip == nil {
+		resp.Error = &v2.Error{
+			Type:   "?ipv4=<ipv4>",
+			Title:  "could not determine client ip from request",
+			Status: http.StatusBadRequest,
+		}
+		rw.WriteHeader(resp.Error.Status)
+		writeResponse(rw, resp)
+		return
+	}
+	iata := rawIata(req)
+	if iata == "" {
+		resp.Error = &v2.Error{
+			Type:   "?iata=<iata>",
+			Title:  "could not determine iata from request",
+			Status: http.StatusBadRequest,
+		}
+		rw.WriteHeader(resp.Error.Status)
+		writeResponse(rw, resp)
+		return
+	}
+	row, err := s.Iata.Find(iata)
+	if err != nil {
+		resp.Error = &v2.Error{
+			Type:   "iata.find",
+			Title:  "could not find given iata in dataset",
+			Status: http.StatusInternalServerError,
+		}
+		rw.WriteHeader(resp.Error.Status)
+		writeResponse(rw, resp)
+		return
+	}
+	param.Metro = row
+
+	record, err := s.Maxmind.City(ip)
+	if err != nil {
+		resp.Error = &v2.Error{
+			Type:   "maxmind.city",
+			Title:  "could not find city metadata from ip",
+			Status: http.StatusInternalServerError,
+		}
+		rw.WriteHeader(resp.Error.Status)
+		writeResponse(rw, resp)
+		return
+	}
+	param.Geo = record
+	param.Network = s.ASN.AnnotateIP(param.IPv4)
+	r := register.CreateRegisterResponse(param)
+
+	// TODO: register hostname in Cloud DNS.
+
+	b, _ := json.MarshalIndent(r, "", " ")
+	rw.Write(b)
 }
 
 // Live reports whether the system is live.
@@ -111,6 +207,24 @@ func (s *Server) Live(rw http.ResponseWriter, req *http.Request) {
 // Ready reports whether the server is ready.
 func (s *Server) Ready(rw http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(rw, "ok")
+}
+
+func rawIata(req *http.Request) string {
+	iata := req.URL.Query().Get("iata")
+	if iata != "" && len(iata) == 3 && isValidName(iata) {
+		return strings.ToLower(iata)
+	}
+	return ""
+}
+
+func isValidName(s string) bool {
+	if s == "" {
+		return false
+	}
+	if len(s) > 10 {
+		return false
+	}
+	return validName.MatchString(s)
 }
 
 func (s *Server) getCountry(req *http.Request) (string, error) {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -154,7 +154,7 @@ func (s *Server) Register(rw http.ResponseWriter, req *http.Request) {
 		writeResponse(rw, resp)
 		return
 	}
-	iata := rawIata(req)
+	iata := getClientIata(req)
 	if iata == "" {
 		resp.Error = &v2.Error{
 			Type:   "?iata=<iata>",
@@ -209,7 +209,7 @@ func (s *Server) Ready(rw http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(rw, "ok")
 }
 
-func rawIata(req *http.Request) string {
+func getClientIata(req *http.Request) string {
 	iata := req.URL.Query().Get("iata")
 	if iata != "" && len(iata) == 3 && isValidName(iata) {
 		return strings.ToLower(iata)

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -10,21 +10,28 @@ import (
 	"testing"
 
 	v0 "github.com/m-lab/autojoin/api/v0"
+	"github.com/m-lab/autojoin/iata"
 	"github.com/m-lab/go/testingx"
+	"github.com/m-lab/uuid-annotator/annotator"
 	"github.com/oschwald/geoip2-golang"
 )
 
 type fakeIataFinder struct {
-	iata  string
-	err   error
-	loads int
+	iata      string
+	lookupErr error
+	loads     int
+	findRow   iata.Row
+	findErr   error
 }
 
 func (f *fakeIataFinder) Lookup(country string, lat, lon float64) (string, error) {
-	if f.err != nil {
-		return "", f.err
+	if f.lookupErr != nil {
+		return "", f.lookupErr
 	}
 	return f.iata, nil
+}
+func (f *fakeIataFinder) Find(airport string) (iata.Row, error) {
+	return f.findRow, f.findErr
 }
 func (f *fakeIataFinder) Load(ctx context.Context) error {
 	f.loads++
@@ -42,6 +49,15 @@ func (f *fakeMaxmind) City(ip net.IP) (*geoip2.City, error) {
 func (f *fakeMaxmind) Reload(ctx context.Context) error {
 	return nil
 }
+
+type fakeAsn struct {
+	ann *annotator.Network
+}
+
+func (f *fakeAsn) AnnotateIP(src string) *annotator.Network {
+	return f.ann
+}
+func (f *fakeAsn) Reload(ctx context.Context) {}
 
 func TestServer_Lookup(t *testing.T) {
 	tests := []struct {
@@ -111,7 +127,7 @@ func TestServer_Lookup(t *testing.T) {
 		},
 		{
 			name:     "error-lookup",
-			iata:     &fakeIataFinder{err: errors.New("fake error")},
+			iata:     &fakeIataFinder{lookupErr: errors.New("fake error")},
 			request:  "?country=US&lat=43&lon=-70",
 			wantCode: http.StatusInternalServerError,
 		},
@@ -172,7 +188,7 @@ func TestServer_Lookup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewServer("mlab-sandbox", tt.iata, tt.maxmind)
+			s := NewServer("mlab-sandbox", tt.iata, tt.maxmind, &fakeAsn{})
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/autojoin/v0/lookup"+tt.request, nil)
 			for key, value := range tt.headers {
@@ -194,7 +210,7 @@ func TestServer_Lookup(t *testing.T) {
 func TestServer_Reload(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		f := &fakeIataFinder{}
-		s := NewServer("mlab-sandbox", f, &fakeMaxmind{})
+		s := NewServer("mlab-sandbox", f, &fakeMaxmind{}, &fakeAsn{})
 		s.Reload(context.Background())
 		if f.loads != 1 {
 			t.Errorf("Reload failed to call iata loader")
@@ -204,7 +220,7 @@ func TestServer_Reload(t *testing.T) {
 
 func TestServer_LiveAndReady(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		s := NewServer("mlab-sandbox", &fakeIataFinder{}, &fakeMaxmind{})
+		s := NewServer("mlab-sandbox", &fakeIataFinder{}, &fakeMaxmind{}, &fakeAsn{})
 		rw := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		s.Live(rw, req)
@@ -213,4 +229,133 @@ func TestServer_LiveAndReady(t *testing.T) {
 		// TODO: remove once handler has a real implementation.
 		s.Register(rw, req)
 	})
+}
+
+func TestServer_Register(t *testing.T) {
+	tests := []struct {
+		name     string
+		Iata     IataFinder
+		Maxmind  MaxmindFinder
+		ASN      ASNFinder
+		params   string
+		wantName string
+		wantCode int
+	}{
+		{
+			name:   "success",
+			params: "?service=foo&organization=bar&iata=lga&ipv4=192.168.0.1",
+			Iata: &fakeIataFinder{
+				findRow: iata.Row{
+					IATA:      "lga",
+					Latitude:  -10,
+					Longitude: -10,
+				},
+			},
+			Maxmind: &fakeMaxmind{
+				// NOTE: this riduculous declaration is needed due to anonymous structs in the geoop2 package.
+				city: &geoip2.City{
+					Country: struct {
+						GeoNameID         uint              `maxminddb:"geoname_id"`
+						IsInEuropeanUnion bool              `maxminddb:"is_in_european_union"`
+						IsoCode           string            `maxminddb:"iso_code"`
+						Names             map[string]string `maxminddb:"names"`
+					}{
+						IsoCode: "US",
+					},
+					Subdivisions: []struct {
+						GeoNameID uint              `maxminddb:"geoname_id"`
+						IsoCode   string            `maxminddb:"iso_code"`
+						Names     map[string]string `maxminddb:"names"`
+					}{
+						{IsoCode: "NY", Names: map[string]string{"en": "New York"}},
+						{IsoCode: "ZZ", Names: map[string]string{"en": "fake thing"}},
+					},
+					Location: struct {
+						AccuracyRadius uint16  `maxminddb:"accuracy_radius"`
+						Latitude       float64 `maxminddb:"latitude"`
+						Longitude      float64 `maxminddb:"longitude"`
+						MetroCode      uint    `maxminddb:"metro_code"`
+						TimeZone       string  `maxminddb:"time_zone"`
+					}{
+						Latitude:  41,
+						Longitude: -73,
+					},
+				},
+			},
+			ASN: &fakeAsn{
+				ann: &annotator.Network{
+					ASNumber: 12345,
+				},
+			},
+			wantName: "foo-lga12345-c0a80001.bar.sandbox.measurement-lab.org",
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "error-service-empty",
+			params:   "?service=",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "error-service-too-long",
+			params:   "?service=abcdefghijklm",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "error-bad-organization",
+			params:   "?service=foo&organization=-BAD-NAME-",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "error-bad-ip",
+			params:   "?service=foo&organization=bar&ipv4=-BAD-IP-",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "error-invalid-iata",
+			params:   "?service=foo&organization=bar&ipv4=192.168.0.1&iata=-invalid-",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "error-bad-iata-find",
+			Iata:     &fakeIataFinder{findErr: errors.New("find err")},
+			params:   "?service=foo&organization=bar&ipv4=192.168.0.1&iata=123",
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name:     "error-bad-maxmind-city",
+			Iata:     &fakeIataFinder{findRow: iata.Row{}},
+			Maxmind:  &fakeMaxmind{err: errors.New("fake maxmind error")},
+			params:   "?service=foo&organization=bar&ipv4=192.168.0.1&iata=abc",
+			wantCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewServer("mlab-sandbox", tt.Iata, tt.Maxmind, tt.ASN)
+			rw := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/autojoin/v0/node/register"+tt.params, nil)
+
+			s.Register(rw, req)
+
+			if rw.Code != tt.wantCode {
+				t.Errorf("Register() returned wrong code; got %d, want %d", rw.Code, tt.wantCode)
+			}
+			if rw.Code != http.StatusOK {
+				return
+			}
+
+			// Check response content.
+			resp := v0.RegisterResponse{}
+			raw := rw.Body.Bytes()
+			// fmt.Println(string(raw))
+			err := json.Unmarshal(raw, &resp)
+			testingx.Must(t, err, "failed to unmarshal response")
+
+			if resp.Registration.Hostname != tt.wantName {
+				t.Errorf("Register() returned wrong hostname; got %s, want %s", resp.Registration.Hostname, tt.wantName)
+			}
+
+		})
+	}
 }

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -226,9 +226,6 @@ func TestServer_LiveAndReady(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		s.Live(rw, req)
 		s.Ready(rw, req)
-
-		// TODO: remove once handler has a real implementation.
-		s.Register(rw, req)
 	})
 }
 


### PR DESCRIPTION
This change adds the beginning of the Register handler to the autojoin API. Currently, the generated hostname is not registered in Cloud DNS, so calling the API has no external effect. The response structure includes the server annotation and heartbeat structures needed by the uuid-annotator and heartbeat service, respectively.


```
curl --dump-header - 'autojoin-dot-mlab-sandbox.appspot.com/autojoin/v0/node/register?iata=lga&service=ndt&organization=mlab'
HTTP/1.1 200 OK
Date: Wed, 06 Mar 2024 23:13:14 GMT
Content-Type: application/json
Content-Length: 1170
Vary: Accept-Encoding
Via: 1.1 google

{
 "Registration": {
  "Hostname": "ndt-lga6128-43530535.mlab.sandbox.measurement-lab.org",
  "Annotation": {
   "Annotation": {
    "Site": "lga6128",
    "Machine": "43530535",
    "Geo": {
     "ContinentCode": "NA",
     "CountryCode": "US",
     "CountryName": "United States",
     "Subdivision1ISOCode": "NJ",
     "Subdivision1Name": "New Jersey",
     "MetroCode": 501,
     "City": "Parsippany",
     "PostalCode": "07054",
     "Latitude": 40.775,
     "Longitude": -73.875
    },
    "Network": {
     "CIDR": "67.80.0.0/14",
     "ASNumber": 6128,
     "Systems": [
      {
       "ASNs": [
        6128
       ]
      }
     ]
    }
   },
   "Network": {
    "IPv4": "67.83.x.xx",
    "IPv6": ""
   },
   "Type": "unknown"
  },
  "Heartbeat": {
   "City": "Parsippany",
   "CountryCode": "US",
   "ContinentCode": "NA",
   "Experiment": "ndt",
   "Hostname": "ndt-lga6128-43530535.mlab.sandbox.measurement-lab.org",
   "Latitude": 40.775,
   "Longitude": -73.875,
   "Machine": "43530535",
   "Metro": "lga",
   "Project": "mlab-sandbox",
   "Probability": 1,
   "Site": "lga6128",
   "Type": "unknown",
   "Uplink": "unknown",
   "Services": null
  }
 }
}
```


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/13)
<!-- Reviewable:end -->
