### PR TITLE
Add Cloud Endpoints configuration for autojoin API

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -6,10 +6,9 @@ runtime_config:
   operating_system: "ubuntu22"
   runtime_version: "1.21"
 
-# TODO(soltesz): enable endpoints configuration.
-#endpoints_api_service:
-#  name: locate-dot-{{PROJECT}}.appspot.com
-#  rollout_strategy: managed
+endpoints_api_service:
+  name: autojoin-dot-{{PROJECT_ID}}.appspot.com
+  rollout_strategy: managed
 
 resources:
   cpu: 2

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,3 +20,6 @@ steps:
   args:
   - sed -i -e 's/{{PROJECT_ID}}/$PROJECT_ID/g' app.yaml
   - gcloud --project $PROJECT_ID app deploy --promote app.yaml
+  # After deploying the new service, deploy the openapi spec.
+  - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' -e 's/{{DEPLOYMENT}}/$PROJECT_ID/' openapi.yaml
+  - gcloud endpoints services deploy openapi.yaml

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,74 @@
+# Copyright 2024, autojoin Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+swagger: "2.0"
+info:
+  description: |-
+    The autojoin API provides dynamic registration of services that are part of
+    M-Lab's global measurement platform.
+  title: "M-Lab Autojoin API ({{DEPLOYMENT}})"
+  version: "0.1.0"
+host: "autojoin-dot-{{PROJECT}}.appspot.com"
+
+consumes:
+- "application/json"
+produces:
+- "application/json"
+schemes:
+- "https"
+
+paths:
+  # DOES NOT require an API key.
+  "/autojoin/v0/lookup":
+    get:
+      description: |-
+        Find the nearest IATA location based on user parameters.
+
+        This resource does not require an API key.
+      operationId: "autojoin-v0-lookup"
+      produces:
+      - "application/json"
+      tags:
+        - public
+
+  ################################################################################
+  # Requires authorization with an API key.
+  "/autojoin/v0/node/register":
+    get:
+      description: |-
+        Register a service with M-Lab.
+
+        This resource requires an API key.
+      operationId: "autojoin-v0-node-register"
+      produces:
+      - "application/json"
+      security:
+      - api_key: []
+      tags:
+        - public
+
+securityDefinitions:
+  # This section configures basic authentication with an API key.
+  # Paths configured with api_key security require an API key for all requests.
+  api_key:
+    type: "apiKey"
+    description: |-
+      An API key for your organization, restricted to the Autojoin API. API keys
+      are allocated by M-Lab for use by a registered organization.
+    name: "key"
+    in: "query"
+
+tags:
+  - name: public
+    description: Public API.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -37,8 +37,24 @@ paths:
 
         This resource does not require an API key.
       operationId: "autojoin-v0-lookup"
+      parameters:
+        - in: query
+          name: country
+          type: string
+          required: false
+          description: Country. If provided, overrides country hints from AppEngine.
+        - in: query
+          name: lat
+          type: number
+          required: false
+          description: Latitude. If provided, overrides location hints from AppEngine.
+        - in: query
+          name: lon
+          type: number
+          required: false
+          description: Longitude. If provided, overrides location hints from AppEngine.
       produces:
-      - "application/json"
+        - "application/json"
       responses:
         '200':
           description: Registration was successful.
@@ -54,8 +70,36 @@ paths:
 
         This resource requires an API key.
       operationId: "autojoin-v0-node-register"
+      parameters:
+        - in: query
+          name: service
+          type: string
+          required: true
+          description: Service name.
+        - in: query
+          name: organization
+          type: string
+          required: true
+          description: Organization name. Must be the name of a previously registered organization.
+        - in: query
+          name: iata
+          type: string
+          required: true
+          description: IATA name. A known, three letter IATA code returned by lookup.
+        - in: query
+          name: ipv4
+          type: string
+          required: false
+          description: IPv4 address. If not provided, the client origin IP is
+            used. If request originates from an IPv6 address, and the ipv4
+            parameter is not provided, registration will fail.
+        - in: query
+          name: ipv6
+          type: string
+          required: false
+          description: IPv6 address.
       produces:
-      - "application/json"
+        - "application/json"
       responses:
         '200':
           description: Registration was successful.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -64,7 +64,7 @@ paths:
   ################################################################################
   # Requires authorization with an API key.
   "/autojoin/v0/node/register":
-    get:
+    post:
       description: |-
         Register a service with M-Lab.
 
@@ -104,7 +104,7 @@ paths:
         '200':
           description: Registration was successful.
       security:
-      - api_key: []
+        - api_key: []
       tags:
         - public
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -39,6 +39,9 @@ paths:
       operationId: "autojoin-v0-lookup"
       produces:
       - "application/json"
+      responses:
+        '200':
+          description: Registration was successful.
       tags:
         - public
 
@@ -53,6 +56,9 @@ paths:
       operationId: "autojoin-v0-node-register"
       produces:
       - "application/json"
+      responses:
+        '200':
+          description: Registration was successful.
       security:
       - api_key: []
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -80,7 +80,8 @@ paths:
           name: organization
           type: string
           required: true
-          description: Organization name. Must be the name of a previously registered organization.
+          description: Organization name. Must be the name of a previously registered
+            organization.
         - in: query
           name: iata
           type: string
@@ -90,14 +91,14 @@ paths:
           name: ipv4
           type: string
           required: false
-          description: IPv4 address. If not provided, the client origin IP is
+          description: IPv4 service address. If not provided, the client origin IP is
             used. If request originates from an IPv6 address, and the ipv4
             parameter is not provided, registration will fail.
         - in: query
           name: ipv6
           type: string
           required: false
-          description: IPv6 address.
+          description: IPv6 service address.
       produces:
         - "application/json"
       responses:


### PR DESCRIPTION
This change adds a basic autojoin API Cloud Endpoints configuration. This configuration requires authorization for the "register" operation. This change allows continuing development of the register operation that makes state changes, such as DNS registration.

Without these changes:
```
$ curl --dump-header - 'autojoin-dot-mlab-sandbox.appspot.com/autojoin/v0/node/register?service=ndt&organization=mlab&iata=lga'
HTTP/1.1 401 Unauthorized
Server: nginx
Date: Fri, 08 Mar 2024 19:00:08 GMT
Content-Type: application/json
Transfer-Encoding: chunked
WWW-Authenticate: Bearer
Via: 1.1 google

{
 "code": 16,
 "message": "Method doesn't allow unregistered callers (callers without established identity). Please use API Key or other form of API consumer identity to call this API.",
 "details": [
  {
   "@type": "type.googleapis.com/google.rpc.DebugInfo",
   "stackEntries": [],
   "detail": "service_control"
  }
 ]
}
```

With an API key:
```
$ curl -XPOST --data {} --dump-header - 'autojoin-dot-mlab-sandbox.appspot.com/autojoin/v0/node/register?service=ndt&organization=mlab&iata=lga&key=KEY'
HTTP/1.1 200 OK
Date: Fri, 08 Mar 2024 19:07:37 GMT
Content-Type: application/json
Content-Length: 1170
Vary: Accept-Encoding
Via: 1.1 google

{
 "Registration": {
  "Hostname": "ndt-lga6128-43530535.mlab.sandbox.measurement-lab.org",
  "Annotation": {
    ...
  },
  "Heartbeat": {
    ...
  }
}
```


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/14)
<!-- Reviewable:end -->
