### PR TITLE
Add DNS registration

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"regexp"
@@ -207,6 +208,7 @@ func (s *Server) Register(rw http.ResponseWriter, req *http.Request) {
 			Title:  "could not register dynamic hostname",
 			Status: http.StatusInternalServerError,
 		}
+		log.Println("dns register failure:", err)
 		rw.WriteHeader(resp.Error.Status)
 		writeResponse(rw, resp)
 		return

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -201,7 +201,7 @@ func (s *Server) Register(rw http.ResponseWriter, req *http.Request) {
 
 	// Register the hostname under the organization zone.
 	m := dnsx.NewManager(s.DNS, s.Project, register.OrgZone(param.Org, s.Project))
-	_, err = m.Register(req.Context(), r.Registration.Hostname, param.IPv4, param.IPv6)
+	_, err = m.Register(req.Context(), r.Registration.Hostname+".", param.IPv4, param.IPv6)
 	if err != nil {
 		resp.Error = &v2.Error{
 			Type:   "dns.register",

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -13,6 +13,8 @@ import (
 
 	v0 "github.com/m-lab/autojoin/api/v0"
 	"github.com/m-lab/autojoin/iata"
+	"github.com/m-lab/autojoin/internal/dnsx"
+	"github.com/m-lab/autojoin/internal/dnsx/dnsiface"
 	"github.com/m-lab/autojoin/internal/register"
 	"github.com/m-lab/go/rtx"
 	v2 "github.com/m-lab/locate/api/v2"
@@ -33,6 +35,7 @@ type Server struct {
 	Iata    IataFinder
 	Maxmind MaxmindFinder
 	ASN     ASNFinder
+	DNS     dnsiface.Service
 }
 
 // ASNFinder is an interface used by the Server to manage ASN information.
@@ -55,12 +58,13 @@ type IataFinder interface {
 }
 
 // NewServer creates a new Server instance for request handling.
-func NewServer(project string, finder IataFinder, maxmind MaxmindFinder, asn ASNFinder) *Server {
+func NewServer(project string, finder IataFinder, maxmind MaxmindFinder, asn ASNFinder, ds dnsiface.Service) *Server {
 	return &Server{
 		Project: project,
 		Iata:    finder,
 		Maxmind: maxmind,
 		ASN:     asn,
+		DNS:     ds,
 	}
 }
 
@@ -194,7 +198,19 @@ func (s *Server) Register(rw http.ResponseWriter, req *http.Request) {
 	param.Network = s.ASN.AnnotateIP(param.IPv4)
 	r := register.CreateRegisterResponse(param)
 
-	// TODO: register hostname in Cloud DNS.
+	// Register the hostname under the organization zone.
+	m := dnsx.NewManager(s.DNS, s.Project, register.OrgZone(param.Org, s.Project))
+	_, err = m.Register(req.Context(), r.Registration.Hostname, param.IPv4, param.IPv6)
+	if err != nil {
+		resp.Error = &v2.Error{
+			Type:   "dns.register",
+			Title:  "could not register dynamic hostname",
+			Status: http.StatusInternalServerError,
+		}
+		rw.WriteHeader(resp.Error.Status)
+		writeResponse(rw, resp)
+		return
+	}
 
 	b, _ := json.MarshalIndent(r, "", " ")
 	rw.Write(b)

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -64,10 +64,11 @@ func (f *fakeAsn) Reload(ctx context.Context) {}
 
 type fakeDNS struct {
 	chgErr error
+	getErr error
 }
 
 func (f *fakeDNS) ResourceRecordSetsGet(ctx context.Context, project string, zone string, name string, rtype string) (*dns.ResourceRecordSet, error) {
-	return nil, nil
+	return nil, f.getErr
 }
 func (f *fakeDNS) ChangeCreate(ctx context.Context, project string, zone string, change *dns.Change) (*dns.Change, error) {
 	return nil, f.chgErr
@@ -382,7 +383,7 @@ func TestServer_Register(t *testing.T) {
 					ASNumber: 12345,
 				},
 			},
-			DNS:      &fakeDNS{chgErr: errors.New("fake change error")},
+			DNS:      &fakeDNS{getErr: errors.New("fake get error")},
 			wantCode: http.StatusInternalServerError,
 		},
 	}

--- a/internal/dnsx/register.go
+++ b/internal/dnsx/register.go
@@ -46,6 +46,9 @@ func (d *Manager) Register(ctx context.Context, hostname, ipv4, ipv6 string) (*d
 	}
 	for _, record := range records {
 		add := false
+		if record.ip == "" {
+			continue
+		}
 		rr, err := d.get(ctx, hostname, record.rtype)
 		if rr != nil {
 			// Found a registration.

--- a/internal/dnsx/register.go
+++ b/internal/dnsx/register.go
@@ -3,6 +3,7 @@ package dnsx
 import (
 	"context"
 	"errors"
+	"log"
 
 	"github.com/m-lab/autojoin/internal/dnsx/dnsiface"
 	"google.golang.org/api/dns/v1"
@@ -65,6 +66,7 @@ func (d *Manager) Register(ctx context.Context, hostname, ipv4, ipv6 string) (*d
 			add = true
 		}
 		// If the error is because the record was not found, add it. Ignore other errors.
+		log.Printf("dns get record: %#v", err)
 		if add || (err != nil && isNotFound(err)) {
 			// Register.
 			chg.Additions = append(chg.Additions,
@@ -120,6 +122,7 @@ func (d *Manager) get(ctx context.Context, hostname, rtype string) (*dns.Resourc
 func isNotFound(err error) bool {
 	var gerr *googleapi.Error
 	if errors.As(err, &gerr) {
+		log.Printf("googleapi.Error: %#v", gerr)
 		return gerr.Code == 404
 	}
 	return false

--- a/internal/dnsx/register.go
+++ b/internal/dnsx/register.go
@@ -34,66 +34,71 @@ func NewManager(s dnsiface.Service, project, zone string) *Manager {
 	}
 }
 
+func appendDeletions(chg *dns.Change, rr *dns.ResourceRecordSet, hostname string) {
+	chg.Deletions = append(chg.Deletions,
+		&dns.ResourceRecordSet{
+			Name:    hostname,
+			Type:    rr.Type,
+			Ttl:     rr.Ttl,
+			Rrdatas: rr.Rrdatas,
+		},
+	)
+}
+
+func appendAdditions(chg *dns.Change, hostname, ip, rtype string) {
+	chg.Additions = append(chg.Additions,
+		&dns.ResourceRecordSet{
+			Name:    hostname,
+			Type:    rtype,
+			Ttl:     300,
+			Rrdatas: []string{ip},
+		},
+	)
+}
+
 // Register creates a new resource record for hostname with the given ipv4 and ipv6 adresses.
 func (d *Manager) Register(ctx context.Context, hostname, ipv4, ipv6 string) (*dns.Change, error) {
-	var err error
 	chg := &dns.Change{}
-	records := []struct {
-		ip    string
-		rtype string
-	}{
-		{ip: ipv4, rtype: recordTypeA},
-		{ip: ipv6, rtype: recordTypeAAAA},
+	var err error
+	var rr *dns.ResourceRecordSet
+
+	// IPv4 is required. An empty ipv4 value will generate an error.
+	rr, err = d.get(ctx, hostname, recordTypeA)
+	if isNotFound(err) {
+		appendAdditions(chg, hostname, ipv4, recordTypeA)
 	}
-	for _, record := range records {
-		add := false
-		if record.ip == "" {
-			continue
+	if rr != nil {
+		// Record matches given parameters, so we do not need to add or delete it.
+		matches := (len(rr.Rrdatas) == 1 && rr.Rrdatas[0] == ipv4)
+		if !matches {
+			// We found an existing resource record that doesn't match the given address.
+			// Remove the old one and add a new one.
+			appendDeletions(chg, rr, hostname)
+			appendAdditions(chg, hostname, ipv4, recordTypeA)
 		}
-		var rr *dns.ResourceRecordSet
-		rr, err = d.get(ctx, hostname, record.rtype)
+	}
+
+	// IPv6 remains optional for now.
+	if ipv6 != "" {
+		rr, err = d.get(ctx, hostname, recordTypeAAAA)
+		if isNotFound(err) {
+			appendAdditions(chg, hostname, ipv6, recordTypeAAAA)
+		}
 		if rr != nil {
-			// Found a registration.
-			if len(rr.Rrdatas) == 1 && rr.Rrdatas[0] == record.ip {
-				// Record matches given parameters, so we do not need to add or
-				// delete it.
-				continue
+			matches := (len(rr.Rrdatas) == 1 && rr.Rrdatas[0] == ipv6)
+			if !matches {
+				appendDeletions(chg, rr, hostname)
+				appendAdditions(chg, hostname, ipv6, recordTypeAAAA)
 			}
-			// But, this record is different from the given parameters, so remove it.
-			chg.Deletions = append(chg.Deletions,
-				&dns.ResourceRecordSet{
-					Name:    hostname,
-					Type:    rr.Type,
-					Ttl:     rr.Ttl,
-					Rrdatas: rr.Rrdatas,
-				},
-			)
-			add = true
-		}
-		// If the error is because the record was not found, add it. Ignore other errors.
-		log.Printf("dns get record: %#v", err)
-		if add || (err != nil && isNotFound(err)) {
-			// Register.
-			chg.Additions = append(chg.Additions,
-				&dns.ResourceRecordSet{
-					Name:    hostname,
-					Type:    record.rtype,
-					Ttl:     300,
-					Rrdatas: []string{record.ip},
-				},
-			)
 		}
 	}
+
 	if chg.Additions == nil && chg.Deletions == nil {
-		// Without any actions, the ChangeCreate will fail with an error.
+		// Without any actions, the ChangeCreate will fail.
 		return nil, err
 	}
-	// Apply changes.
-	result, err := d.Service.ChangeCreate(ctx, d.Project, d.Zone, chg)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+
+	return d.Service.ChangeCreate(ctx, d.Project, d.Zone, chg)
 }
 
 // Delete removes all resource records associated with the given hostname.
@@ -101,25 +106,16 @@ func (d *Manager) Delete(ctx context.Context, hostname string) (*dns.Change, err
 	chg := &dns.Change{}
 	for _, rtype := range []string{recordTypeA, recordTypeAAAA} {
 		rr, err := d.get(ctx, hostname, rtype)
-		if rr != nil {
-			// A record was found, so let's plan to delete it.
-			chg.Deletions = append(chg.Deletions, &dns.ResourceRecordSet{
-				Name:    rr.Name,
-				Type:    rr.Type,
-				Ttl:     rr.Ttl,
-				Rrdatas: rr.Rrdatas,
-			})
-		}
 		if err != nil && !isNotFound(err) {
 			// A different error occured. The host record may or may not exist.
 			return nil, err
 		}
+		if rr != nil {
+			// Remove the record we found.
+			appendDeletions(chg, rr, hostname)
+		}
 	}
-	result, err := d.Service.ChangeCreate(ctx, d.Project, d.Zone, chg)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+	return d.Service.ChangeCreate(ctx, d.Project, d.Zone, chg)
 }
 
 // get retrieves a resource record for the given hostname and rtype.
@@ -129,6 +125,9 @@ func (d *Manager) get(ctx context.Context, hostname, rtype string) (*dns.Resourc
 
 // checks whether this is a googleapi.Error for "not found".
 func isNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
 	var gerr *googleapi.Error
 	if errors.As(err, &gerr) {
 		log.Printf("googleapi.Error: %#v", gerr)

--- a/internal/dnsx/register_test.go
+++ b/internal/dnsx/register_test.go
@@ -29,6 +29,9 @@ func (f *fakeDNS) ResourceRecordSetsGet(ctx context.Context, project string, zon
 }
 
 func (f *fakeDNS) ChangeCreate(ctx context.Context, project string, zone string, change *dns.Change) (*dns.Change, error) {
+	if change.Additions == nil && change.Deletions == nil {
+		return nil, errors.New("fake change create error")
+	}
 	return change, f.chgErr
 }
 

--- a/internal/dnsx/register_test.go
+++ b/internal/dnsx/register_test.go
@@ -44,7 +44,25 @@ func TestManager_Register(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name: "success",
+			name:     "success",
+			zone:     "sandbox-measurement-lab-org",
+			service:  &fakeDNS{getErr: &googleapi.Error{Code: 404}},
+			hostname: "foo.sandbox.measurement-lab.org",
+			ipv4:     "192.168.0.1",
+			ipv6:     "",
+			want: &dns.Change{
+				Additions: []*dns.ResourceRecordSet{
+					{
+						Name:    "foo.sandbox.measurement-lab.org",
+						Type:    "A",
+						Ttl:     300,
+						Rrdatas: []string{"192.168.0.1"},
+					},
+				},
+			},
+		},
+		{
+			name: "success-ipv6",
 			zone: "sandbox-measurement-lab-org",
 			service: &fakeDNS{record: []*dns.ResourceRecordSet{
 				{

--- a/internal/register/register.go
+++ b/internal/register/register.go
@@ -29,6 +29,12 @@ type Params struct {
 	Network *annotator.Network
 }
 
+// OrgZone generates the organization zone name based the organization and project.
+func OrgZone(org, project string) string {
+	// NOTE: prefix prevents name collision with existing zones when the org is "mlab".
+	return "autojoin-" + org + "-" + strings.TrimPrefix(project, "mlab-") + "-measurement-lab-org"
+}
+
 // CreateRegisterResponse generates a RegisterResponse from the given
 // parameters. As an internal package, the caller is required to validate all
 // input parameters.

--- a/internal/register/register.go
+++ b/internal/register/register.go
@@ -42,7 +42,7 @@ func CreateRegisterResponse(p *Params) v0.RegisterResponse {
 	// Calculate machine, site, and hostname.
 	machine := hex.EncodeToString(net.ParseIP(p.IPv4).To4())
 	site := fmt.Sprintf("%s%d", p.Metro.IATA, p.Network.ASNumber)
-	hostname := fmt.Sprintf("%s-%s-%s.%s.%s.%s", p.Service, site, machine, p.Org, strings.TrimPrefix(p.Project, "mlab-"), mlabDomain)
+	hostname := fmt.Sprintf("%s-%s-%s.%s.%s.%s.", p.Service, site, machine, p.Org, strings.TrimPrefix(p.Project, "mlab-"), mlabDomain)
 
 	// Using these, create geo annotation.
 	geo := &annotator.Geolocation{

--- a/internal/register/register.go
+++ b/internal/register/register.go
@@ -42,7 +42,7 @@ func CreateRegisterResponse(p *Params) v0.RegisterResponse {
 	// Calculate machine, site, and hostname.
 	machine := hex.EncodeToString(net.ParseIP(p.IPv4).To4())
 	site := fmt.Sprintf("%s%d", p.Metro.IATA, p.Network.ASNumber)
-	hostname := fmt.Sprintf("%s-%s-%s.%s.%s.%s.", p.Service, site, machine, p.Org, strings.TrimPrefix(p.Project, "mlab-"), mlabDomain)
+	hostname := fmt.Sprintf("%s-%s-%s.%s.%s.%s", p.Service, site, machine, p.Org, strings.TrimPrefix(p.Project, "mlab-"), mlabDomain)
 
 	// Using these, create geo annotation.
 	geo := &annotator.Geolocation{

--- a/internal/register/register_test.go
+++ b/internal/register/register_test.go
@@ -115,3 +115,26 @@ func TestCreateRegisterResponse(t *testing.T) {
 		})
 	}
 }
+
+func TestOrgZone(t *testing.T) {
+	tests := []struct {
+		name    string
+		org     string
+		project string
+		want    string
+	}{
+		{
+			name:    "success",
+			org:     "mlab",
+			project: "mlab-sandbox",
+			want:    "autojoin-mlab-sandbox-measurement-lab-org",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := OrgZone(tt.org, tt.project); got != tt.want {
+				t.Errorf("OrgZone() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/register/register_test.go
+++ b/internal/register/register_test.go
@@ -65,7 +65,7 @@ func TestCreateRegisterResponse(t *testing.T) {
 			},
 			want: v0.RegisterResponse{
 				Registration: &v0.Registration{
-					Hostname: "ndt-lga12345-c0a80001.bar.sandbox.measurement-lab.org.",
+					Hostname: "ndt-lga12345-c0a80001.bar.sandbox.measurement-lab.org",
 					Annotation: &v0.ServerAnnotation{
 						Annotation: annotator.ServerAnnotations{
 							Site:    "lga12345",
@@ -91,7 +91,7 @@ func TestCreateRegisterResponse(t *testing.T) {
 					Heartbeat: &v2.Registration{
 						CountryCode: "US",
 						Experiment:  "ndt",
-						Hostname:    "ndt-lga12345-c0a80001.bar.sandbox.measurement-lab.org.",
+						Hostname:    "ndt-lga12345-c0a80001.bar.sandbox.measurement-lab.org",
 						Latitude:    -10,
 						Longitude:   -10,
 						Machine:     "c0a80001",

--- a/internal/register/register_test.go
+++ b/internal/register/register_test.go
@@ -65,7 +65,7 @@ func TestCreateRegisterResponse(t *testing.T) {
 			},
 			want: v0.RegisterResponse{
 				Registration: &v0.Registration{
-					Hostname: "ndt-lga12345-c0a80001.bar.sandbox.measurement-lab.org",
+					Hostname: "ndt-lga12345-c0a80001.bar.sandbox.measurement-lab.org.",
 					Annotation: &v0.ServerAnnotation{
 						Annotation: annotator.ServerAnnotations{
 							Site:    "lga12345",
@@ -91,7 +91,7 @@ func TestCreateRegisterResponse(t *testing.T) {
 					Heartbeat: &v2.Registration{
 						CountryCode: "US",
 						Experiment:  "ndt",
-						Hostname:    "ndt-lga12345-c0a80001.bar.sandbox.measurement-lab.org",
+						Hostname:    "ndt-lga12345-c0a80001.bar.sandbox.measurement-lab.org.",
 						Latitude:    -10,
 						Longitude:   -10,
 						Machine:     "c0a80001",


### PR DESCRIPTION
Now that the register resource is protected by Cloud Endpoints and required api keys, this change adds DNS registration to the autojoin Register handler.

This change refactors the dnsx.Register logic to be easier to follow for the ipv4 and ipv6 cases and to handle real-world error cases the original logic did not.

This functionality depends on updates to siteinfo's zone definitions. https://github.com/m-lab/siteinfo/pull/325 (now merged and deployed). The autojoin API has no production deployment currently, but will similarly require updates to siteinfo first.

Example usage:

```
$ curl -XPOST --data {} --dump-header - 'autojoin-dot-mlab-sandbox.appspot.com/autojoin/v0/node/register?service=ndt&iata=lga&organization=mlab&key=<key>'
HTTP/1.1 200 OK
Date: Thu, 14 Mar 2024 18:19:32 GMT
Content-Type: application/json
Content-Length: 1170
Vary: Accept-Encoding
Via: 1.1 google

{
 "Registration": {
  "Hostname": "ndt-lga6128-43530535.mlab.sandbox.measurement-lab.org",
  "Annotation": {
    ...
  },
  "Heartbeat": {
    ...
  }
}

$ host ndt-lga6128-43530535.mlab.sandbox.measurement-lab.org
ndt-lga6128-43530535.mlab.sandbox.measurement-lab.org has address 67.83.5.53
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/15)
<!-- Reviewable:end -->
