### PR TITLE
Add v0/node/delete handler

### DIFF
--- a/api/v0/api.go
+++ b/api/v0/api.go
@@ -22,7 +22,7 @@ type RegisterResponse struct {
 	Registration *Registration `json:",omitempty"`
 }
 
-// DeleteResponse is returned by an unregister request.
+// DeleteResponse is returned by a delete request.
 type DeleteResponse struct {
 	Error *v2.Error `json:",omitempty"`
 }

--- a/api/v0/api.go
+++ b/api/v0/api.go
@@ -22,6 +22,11 @@ type RegisterResponse struct {
 	Registration *Registration `json:",omitempty"`
 }
 
+// DeleteResponse is returned by an unregister request.
+type DeleteResponse struct {
+	Error *v2.Error `json:",omitempty"`
+}
+
 // Network contains IPv4 and IPv6 addresses.
 type Network struct {
 	IPv4 string

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -241,7 +241,7 @@ func (s *Server) Delete(rw http.ResponseWriter, req *http.Request) {
 
 	log.Printf("Unregistering hostname: %v", name)
 	m := dnsx.NewManager(s.DNS, s.Project, register.OrgZone(name.Org, s.Project))
-	_, err = m.Delete(req.Context(), hostname)
+	_, err = m.Delete(req.Context(), name.StringAll())
 	if err != nil {
 		resp.Error = &v2.Error{
 			Type:   "dns.delete",

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -239,7 +239,6 @@ func (s *Server) Delete(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	log.Printf("Unregistering hostname: %v", name)
 	m := dnsx.NewManager(s.DNS, s.Project, register.OrgZone(name.Org, s.Project))
 	_, err = m.Delete(req.Context(), name.StringAll()+".")
 	if err != nil {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -241,7 +241,7 @@ func (s *Server) Delete(rw http.ResponseWriter, req *http.Request) {
 
 	log.Printf("Unregistering hostname: %v", name)
 	m := dnsx.NewManager(s.DNS, s.Project, register.OrgZone(name.Org, s.Project))
-	_, err = m.Delete(req.Context(), name.StringAll())
+	_, err = m.Delete(req.Context(), name.StringAll()+".")
 	if err != nil {
 		resp.Error = &v2.Error{
 			Type:   "dns.delete",

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -29,10 +29,6 @@ var (
 	errLocationFormat   = errors.New("location could not be parsed")
 
 	validName = regexp.MustCompile(`[a-z0-9]+`)
-
-	jsonMarshalIndent = func(v interface{}, prefix, indent string) ([]byte, error) {
-		return json.MarshalIndent(v, prefix, indent)
-	}
 )
 
 // Server maintains shared state for the server.
@@ -257,19 +253,8 @@ func (s *Server) Delete(rw http.ResponseWriter, req *http.Request) {
 		writeResponse(rw, resp)
 		return
 	}
-	b, err := jsonMarshalIndent(resp, "", " ")
-	if err != nil {
-		resp.Error = &v2.Error{
-			Type:   "dns.delete",
-			Title:  "failed to marshal response",
-			Detail: err.Error(),
-			Status: http.StatusInternalServerError,
-		}
-		log.Println("dns delete failure:", err)
-		rw.WriteHeader(resp.Error.Status)
-		writeResponse(rw, resp)
-		return
-	}
+	b, err := json.MarshalIndent(resp, "", " ")
+	rtx.Must(err, "failed to marshal DNS delete response")
 	rw.Write(b)
 }
 

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -426,3 +426,49 @@ func TestServer_Register(t *testing.T) {
 		})
 	}
 }
+
+func TestServer_Delete(t *testing.T) {
+	tests := []struct {
+		name     string
+		DNS      dnsiface.Service
+		qs       string
+		wantName string
+		wantCode int
+	}{
+		{
+			name:     "success",
+			qs:       "?hostname=ndt-lga3269-4f20bd89.mlab.sandbox.measurement-lab.org",
+			wantCode: http.StatusOK,
+			DNS:      &fakeDNS{},
+		},
+		{
+			name:     "error-hostname-empty",
+			qs:       "?hostname=",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "error-hostname-invalid",
+			qs:       "?hostname=this-is-not-valid.foo",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "error-request-failed",
+			qs:       "?hostname=ndt-lga3269-4f20bd89.mlab.sandbox.measurement-lab.org",
+			wantCode: http.StatusInternalServerError,
+			DNS:      &fakeDNS{getErr: errors.New("fake error")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewServer("mlab-sandbox", nil, nil, nil, tt.DNS)
+			rw := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/autojoin/v0/node/delete"+tt.qs, nil)
+
+			s.Delete(rw, req)
+
+			if rw.Code != tt.wantCode {
+				t.Errorf("Delete() returned wrong code; got %d, want %d", rw.Code, tt.wantCode)
+			}
+		})
+	}
+}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -429,12 +429,11 @@ func TestServer_Register(t *testing.T) {
 
 func TestServer_Delete(t *testing.T) {
 	tests := []struct {
-		name        string
-		DNS         dnsiface.Service
-		qs          string
-		wantName    string
-		wantCode    int
-		marshalFail bool
+		name     string
+		DNS      dnsiface.Service
+		qs       string
+		wantName string
+		wantCode int
 	}{
 		{
 			name:     "success",
@@ -459,11 +458,10 @@ func TestServer_Delete(t *testing.T) {
 			DNS:      &fakeDNS{getErr: errors.New("fake error")},
 		},
 		{
-			name:        "error-marshal-failed",
-			qs:          "?hostname=ndt-lga3269-4f20bd89.mlab.sandbox.measurement-lab.org",
-			wantCode:    http.StatusInternalServerError,
-			DNS:         &fakeDNS{},
-			marshalFail: true,
+			name:     "error-marshal-failed",
+			qs:       "?hostname=ndt-lga3269-4f20bd89.mlab.sandbox.measurement-lab.org",
+			wantCode: http.StatusInternalServerError,
+			DNS:      &fakeDNS{},
 		},
 	}
 	for _, tt := range tests {
@@ -471,13 +469,6 @@ func TestServer_Delete(t *testing.T) {
 			s := NewServer("mlab-sandbox", nil, nil, nil, tt.DNS)
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/autojoin/v0/node/delete"+tt.qs, nil)
-			if tt.marshalFail {
-				oldJSONMarshalIndent := jsonMarshalIndent
-				jsonMarshalIndent = func(v interface{}, prefix, indent string) ([]byte, error) {
-					return nil, errors.New("fake error")
-				}
-				defer func() { jsonMarshalIndent = oldJSONMarshalIndent }()
-			}
 			s.Delete(rw, req)
 
 			if rw.Code != tt.wantCode {

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -457,12 +457,6 @@ func TestServer_Delete(t *testing.T) {
 			wantCode: http.StatusInternalServerError,
 			DNS:      &fakeDNS{getErr: errors.New("fake error")},
 		},
-		{
-			name:     "error-marshal-failed",
-			qs:       "?hostname=ndt-lga3269-4f20bd89.mlab.sandbox.measurement-lab.org",
-			wantCode: http.StatusInternalServerError,
-			DNS:      &fakeDNS{},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -429,11 +429,12 @@ func TestServer_Register(t *testing.T) {
 
 func TestServer_Delete(t *testing.T) {
 	tests := []struct {
-		name     string
-		DNS      dnsiface.Service
-		qs       string
-		wantName string
-		wantCode int
+		name        string
+		DNS         dnsiface.Service
+		qs          string
+		wantName    string
+		wantCode    int
+		marshalFail bool
 	}{
 		{
 			name:     "success",
@@ -457,13 +458,26 @@ func TestServer_Delete(t *testing.T) {
 			wantCode: http.StatusInternalServerError,
 			DNS:      &fakeDNS{getErr: errors.New("fake error")},
 		},
+		{
+			name:        "error-marshal-failed",
+			qs:          "?hostname=ndt-lga3269-4f20bd89.mlab.sandbox.measurement-lab.org",
+			wantCode:    http.StatusInternalServerError,
+			DNS:         &fakeDNS{},
+			marshalFail: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewServer("mlab-sandbox", nil, nil, nil, tt.DNS)
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/autojoin/v0/node/delete"+tt.qs, nil)
-
+			if tt.marshalFail {
+				oldJSONMarshalIndent := jsonMarshalIndent
+				jsonMarshalIndent = func(v interface{}, prefix, indent string) ([]byte, error) {
+					return nil, errors.New("fake error")
+				}
+				defer func() { jsonMarshalIndent = oldJSONMarshalIndent }()
+			}
 			s.Delete(rw, req)
 
 			if rw.Code != tt.wantCode {

--- a/internal/dnsx/register.go
+++ b/internal/dnsx/register.go
@@ -107,6 +107,7 @@ func (d *Manager) Delete(ctx context.Context, hostname string) (*dns.Change, err
 	for _, rtype := range []string{recordTypeA, recordTypeAAAA} {
 		rr, err := d.get(ctx, hostname, rtype)
 		if err != nil && !isNotFound(err) {
+			log.Println(err)
 			// A different error occured. The host record may or may not exist.
 			return nil, err
 		}

--- a/internal/dnsx/register.go
+++ b/internal/dnsx/register.go
@@ -107,7 +107,6 @@ func (d *Manager) Delete(ctx context.Context, hostname string) (*dns.Change, err
 	for _, rtype := range []string{recordTypeA, recordTypeAAAA} {
 		rr, err := d.get(ctx, hostname, rtype)
 		if err != nil && !isNotFound(err) {
-			log.Println(err)
 			// A different error occured. The host record may or may not exist.
 			return nil, err
 		}

--- a/main.go
+++ b/main.go
@@ -113,6 +113,10 @@ func main() {
 		RequestHandlerDuration.MustCurryWith(prometheus.Labels{"path": "/autojoin/v0/node/register"}),
 		http.HandlerFunc(s.Register)))
 
+	mux.HandleFunc("/autojoin/v0/node/delete", promhttp.InstrumentHandlerDuration(
+		RequestHandlerDuration.MustCurryWith(prometheus.Labels{"path": "/autojoin/v0/node/delete"}),
+		http.HandlerFunc(s.Delete)))
+
 	// Liveness and Readiness checks to support deployments.
 	mux.HandleFunc("/v0/live", s.Live)
 	mux.HandleFunc("/v0/ready", s.Ready)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -108,6 +108,28 @@ paths:
         - api_key: []
       tags:
         - public
+  "/autojoin/v0/node/delete":
+    post:
+      description: |-
+        Delete a hostname from M-Lab.
+
+        This resource requires an API key.
+      operationId: "autojoin-v0-node-delete"
+      parameters:
+        - in: query
+          name: hostname
+          type: string
+          required: true
+          description: Hostname to delete.
+      produces:
+        - "application/json"
+      responses:
+        '200':
+          description: Deletion was successful.
+      security:
+        - api_key: []
+      tags:
+        - public
 
 securityDefinitions:
   # This section configures basic authentication with an API key.


### PR DESCRIPTION
This PR adds a `autojoin/v0/node/delete` handler that removes the DNS entry for the requested hostname, which is meant to be called by Locate once the timeout for an autojoined node has expired.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/21)
<!-- Reviewable:end -->
