### PR TITLE
Make client a service with configurable registration -interval

### DIFF
--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -81,7 +80,6 @@ func register() {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		fmt.Println(resp.Status)
 		panic("Failed to register with autojoin service")
 	}
 

--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"flag"
 	"io"
@@ -48,13 +47,9 @@ func main() {
 
 	// Keep retrying registration every configured interval.
 	t := time.NewTicker(*interval)
-	go func() {
-		for range t.C {
-			register()
-		}
-	}()
-
-	<-context.Background().Done()
+	for range t.C {
+		register()
+	}
 }
 
 // Make a call to the register endpoint and write the resulting config files to


### PR DESCRIPTION
This PR turns the autojoin `register` client into a service that retries the registration every `-interval` . The registration should be idempotent so that if a node already exists this will just return the same configuration JSON and no DNS entries nor API keys are created.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/22)
<!-- Reviewable:end -->
