### PR TITLE
Add -probability flag for register command

### DIFF
--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -80,7 +80,7 @@ func register() {
 	q.Add("iata", *iata)
 	q.Add("ipv4", *ipv4)
 	q.Add("ipv6", *ipv6)
-	q.Add("probability", *siteProb)
+	q.Add("probability", fmt.Sprintf("%f", *siteProb))
 	registerURL.RawQuery = q.Encode()
 
 	log.Printf("Registering with %s", registerURL)

--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -38,6 +38,7 @@ var (
 	intervalMin = flag.Duration("interval.min", 55*time.Minute, "Minimum registration interval")
 	intervalMax = flag.Duration("interval.max", 65*time.Minute, "Maximum registration interval")
 	outputPath  = flag.String("output", "", "Output folder")
+	siteProb    = flag.Float64("probability", 1.0, "Default probability of returning this site for a Locate result")
 )
 
 func main() {
@@ -45,6 +46,9 @@ func main() {
 
 	if *endpoint == "" || *apiKey == "" || *service == "" || *org == "" || *iata == "" {
 		panic("-key, -service, -organization, and -iata are required.")
+	}
+	if *siteProb <= 0.0 || *siteProb > 1.0 {
+		panic("-probability must be in the range (0, 1]")
 	}
 
 	register()
@@ -76,6 +80,7 @@ func register() {
 	q.Add("iata", *iata)
 	q.Add("ipv4", *ipv4)
 	q.Add("ipv6", *ipv6)
+	q.Add("probability", *siteProb)
 	registerURL.RawQuery = q.Encode()
 
 	log.Printf("Registering with %s", registerURL)

--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"io"
 	"log"
 	"net/http"


### PR DESCRIPTION
This change adds a new flag to the register command for site `-probability`. This probability will override the Heartbeat Registration `Probability` field used by Locate to specify how frequently to return this node in Locate results.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/24)
<!-- Reviewable:end -->
