### PR TITLE
Fix v0.Network in register responses

### DIFF
--- a/internal/register/register.go
+++ b/internal/register/register.go
@@ -66,11 +66,11 @@ func CreateRegisterResponse(p *Params) v0.RegisterResponse {
 	}
 
 	// A v0.Network must contain a valid CIDR, so we convert the v4/v6
-	// addresses to a /32 or a /64 here.
+	// addresses to a /32 or a /128 here.
 	ipv4CIDR := p.IPv4 + "/32"
 	ipv6CIDR := ""
 	if p.IPv6 != "" {
-		ipv6CIDR = p.IPv6 + "/64"
+		ipv6CIDR = p.IPv6 + "/128"
 	}
 
 	// Put everything together into a RegisterResponse.

--- a/internal/register/register.go
+++ b/internal/register/register.go
@@ -65,6 +65,17 @@ func CreateRegisterResponse(p *Params) v0.RegisterResponse {
 		}
 	}
 
+	// A v0.Network must contain a valid CIDR, so we convert the v4/v6
+	// addresses to a /32 or a /64 here.
+	ipv4CIDR := ""
+	ipv6CIDR := ""
+	if p.IPv4 != "" {
+		ipv4CIDR = p.IPv4 + "/32"
+	}
+	if p.IPv6 != "" {
+		ipv6CIDR = p.IPv6 + "/64"
+	}
+
 	// Put everything together into a RegisterResponse.
 	r := v0.RegisterResponse{
 		Registration: &v0.Registration{
@@ -77,8 +88,8 @@ func CreateRegisterResponse(p *Params) v0.RegisterResponse {
 					Network: p.Network,
 				},
 				Network: v0.Network{
-					IPv4: p.IPv4,
-					IPv6: p.IPv6,
+					IPv4: ipv4CIDR,
+					IPv6: ipv6CIDR,
 				},
 				Type: "unknown", // should be overridden by node.
 			},

--- a/internal/register/register.go
+++ b/internal/register/register.go
@@ -67,11 +67,8 @@ func CreateRegisterResponse(p *Params) v0.RegisterResponse {
 
 	// A v0.Network must contain a valid CIDR, so we convert the v4/v6
 	// addresses to a /32 or a /64 here.
-	ipv4CIDR := ""
+	ipv4CIDR := p.IPv4 + "/32"
 	ipv6CIDR := ""
-	if p.IPv4 != "" {
-		ipv4CIDR = p.IPv4 + "/32"
-	}
 	if p.IPv6 != "" {
 		ipv6CIDR = p.IPv6 + "/64"
 	}

--- a/internal/register/register_test.go
+++ b/internal/register/register_test.go
@@ -25,7 +25,7 @@ func TestCreateRegisterResponse(t *testing.T) {
 				Service: "ndt",
 				Org:     "bar",
 				IPv4:    "192.168.0.1",
-				IPv6:    "",
+				IPv6:    "::1",
 				Geo: &geoip2.City{
 					Country: struct {
 						GeoNameID         uint              `maxminddb:"geoname_id"`
@@ -85,6 +85,7 @@ func TestCreateRegisterResponse(t *testing.T) {
 						},
 						Network: v0.Network{
 							IPv4: "192.168.0.1/32",
+							IPv6: "::1/128",
 						},
 						Type: "unknown",
 					},

--- a/internal/register/register_test.go
+++ b/internal/register/register_test.go
@@ -84,7 +84,7 @@ func TestCreateRegisterResponse(t *testing.T) {
 							},
 						},
 						Network: v0.Network{
-							IPv4: "192.168.0.1",
+							IPv4: "192.168.0.1/32",
 						},
 						Type: "unknown",
 					},


### PR DESCRIPTION
Fields in `v0.Network` are expected to be valid CIDRs. This unconditionally adds `/32` to the IPv4 (since it's always a single address for autojoined nodes) and `/128` to the IPv6 address when available.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/26)
<!-- Reviewable:end -->
