### PR TITLE
Add /ready endpoint + use alpine in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN go mod download
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /go/bin/register ./cmd/register
 
 # Run stage.
-FROM gcr.io/distroless/static-debian12:latest
+FROM alpine:3.20
+RUN apk add curl
 COPY --from=builder /go/bin/register .
 ENTRYPOINT ["/register"]

--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"sync/atomic"
 	"time"
 
 	v0 "github.com/m-lab/autojoin/api/v0"
@@ -41,11 +42,11 @@ var (
 	siteProb    = flag.Float64("probability", 1.0, "Default probability of returning this site for a Locate result")
 
 	hcAddr          = flag.String("healthcheck-addr", "localhost:8001", "Address to serve the /ready endpoint on")
-	registerSuccess bool
+	registerSuccess atomic.Bool
 )
 
 func Ready(rw http.ResponseWriter, req *http.Request) {
-	if registerSuccess {
+	if registerSuccess.Load() {
 		rw.WriteHeader(http.StatusOK)
 	} else {
 		rw.WriteHeader(http.StatusServiceUnavailable)
@@ -138,5 +139,5 @@ func register() {
 	rtx.Must(err, "Failed to write annotation file")
 
 	log.Printf("Registration successful with hostname: %s", r.Registration.Hostname)
-	registerSuccess = true
+	registerSuccess.Store(true)
 }


### PR DESCRIPTION
This PR adds a `/ready` endpoint that returns an HTTP code of 200 if the registration was successful, 503 otherwise. This endpoint can be used to perform health checks in e.g. a docker compose.

The move to alpine is due to `curl` (needed for health checks) not being included in distroless images.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/28)
<!-- Reviewable:end -->
