### PR TITLE
Connect List API to memorystore

### DIFF
--- a/internal/tracker/gc_test.go
+++ b/internal/tracker/gc_test.go
@@ -114,7 +114,7 @@ func TestGarbageCollector_checkAndRemoveExpired(t *testing.T) {
 
 	gc := NewGarbageCollector(dns, "test-project", fakeMSClient, 3*time.Hour, 1*time.Hour)
 
-	gc.checkAndRemoveExpired()
+	gc.List()
 	// Check that the expired record was removed.
 	if _, ok := fakeMSClient.m["foo-lga12345-c0a80001.bar.sandbox.measurement-lab.org"]; ok {
 		t.Errorf("checkAndRemoveExpired() failed to remove expired record.")
@@ -130,7 +130,7 @@ func TestGarbageCollector_checkAndRemoveExpired(t *testing.T) {
 			LastUpdate: 0,
 		},
 	}
-	gc.checkAndRemoveExpired()
+	gc.List()
 	// Check that the un-parseable hostname was ignored.
 	if _, ok := fakeMSClient.m["invalid"]; !ok {
 		t.Errorf("checkAndRemoveExpired() failed to ignore an un-parseable hostname.")

--- a/internal/tracker/gc_test.go
+++ b/internal/tracker/gc_test.go
@@ -28,6 +28,7 @@ func (f *fakeDNS) ChangeCreate(ctx context.Context, project string, zone string,
 type fakeMemorystoreClient[V any] struct {
 	putErr error
 	delErr error
+	getErr error
 	m      map[string]V
 }
 
@@ -38,7 +39,7 @@ func (c *fakeMemorystoreClient[V]) Put(key string, field string, value redis.Sca
 
 // GetAll returns an empty map and a nil error.
 func (c *fakeMemorystoreClient[V]) GetAll() (map[string]V, error) {
-	return c.m, nil
+	return c.m, c.getErr
 }
 
 // Del returns nil
@@ -93,7 +94,7 @@ func TestGarbageCollector_Update(t *testing.T) {
 	}
 }
 
-func TestGarbageCollector_checkAndRemoveExpired(t *testing.T) {
+func TestGarbageCollector_List(t *testing.T) {
 	dns := &fakeDNS{}
 	fakeMSClient := &fakeMemorystoreClient[Status]{
 		m: map[string]Status{
@@ -117,11 +118,11 @@ func TestGarbageCollector_checkAndRemoveExpired(t *testing.T) {
 	gc.List()
 	// Check that the expired record was removed.
 	if _, ok := fakeMSClient.m["foo-lga12345-c0a80001.bar.sandbox.measurement-lab.org"]; ok {
-		t.Errorf("checkAndRemoveExpired() failed to remove expired record.")
+		t.Errorf("List() failed to remove expired record.")
 	}
 	// Check that the non-expired record was NOT removed.
 	if _, ok := fakeMSClient.m["foo-lga12345-c0a80002.bar.sandbox.measurement-lab.org"]; !ok {
-		t.Errorf("checkAndRemoveExpired() removed a non-expired record.")
+		t.Errorf("List() removed a non-expired record.")
 	}
 
 	// Add un-parseable hostname
@@ -133,7 +134,14 @@ func TestGarbageCollector_checkAndRemoveExpired(t *testing.T) {
 	gc.List()
 	// Check that the un-parseable hostname was ignored.
 	if _, ok := fakeMSClient.m["invalid"]; !ok {
-		t.Errorf("checkAndRemoveExpired() failed to ignore an un-parseable hostname.")
+		t.Errorf("List() failed to ignore an un-parseable hostname.")
+	}
+
+	// Inject error into GetAll
+	fakeMSClient.getErr = errors.New("fake getall error")
+	_, err := gc.List()
+	if err != fakeMSClient.getErr {
+		t.Errorf("List() failed for unexpected reason; got %v; want %v", err, fakeMSClient.getErr)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -65,14 +65,6 @@ func init() {
 
 var mainCtx, mainCancel = context.WithCancel(context.Background())
 
-// TODO(soltesz): query memorystore for list of known hosts.
-type FakeRecordLister struct{}
-
-// List is a fake implementation of the RecordLister interface.
-func (r *FakeRecordLister) List() ([]string, error) {
-	return []string{}, nil
-}
-
 func main() {
 	flag.Parse()
 	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not parse env args")
@@ -115,7 +107,7 @@ func main() {
 	defer gc.Stop()
 
 	// Create server.
-	s := handler.NewServer(project, i, mm, asn, d, gc, &FakeRecordLister{})
+	s := handler.NewServer(project, i, mm, asn, d, gc)
 	go func() {
 		// Load once.
 		s.Iata.Load(mainCtx)


### PR DESCRIPTION
This change removes the `RecordLister` interface in favor of extending the `DNSTracker` interface to include a `List()` operation. This change also adds `List` to the `GarbageCollector` type, which returns all known servers. The implementation relies on a modification to `checkAndRemoveExpired` to return unexpired hostnames, making every `List()` operation an implied GC run.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/31)
<!-- Reviewable:end -->
