### PR TITLE
List returns multiple ports for monitoring

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -478,9 +478,6 @@ func getProbability(req *http.Request) float64 {
 func getPorts(req *http.Request) []string {
 	result := []string{}
 	ports := req.URL.Query()["ports"]
-	if len(ports) == 0 {
-		return []string{"9990"} // default port
-	}
 	for _, port := range ports {
 		// Verify this is a valid number.
 		_, err := strconv.ParseInt(port, 10, 64)

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -63,9 +63,9 @@ type IataFinder interface {
 }
 
 type DNSTracker interface {
-	Update(string) error
+	Update(string, []string) error
 	Delete(string) error
-	List() ([]string, error)
+	List() ([]string, [][]string, error)
 }
 
 // NewServer creates a new Server instance for request handling.
@@ -231,7 +231,7 @@ func (s *Server) Register(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	// Add the hostname to the DNS tracker.
-	err = s.dnsTracker.Update(r.Registration.Hostname)
+	err = s.dnsTracker.Update(r.Registration.Hostname, getPorts(req))
 	if err != nil {
 		resp.Error = &v2.Error{
 			Type:   "tracker.gc",
@@ -309,7 +309,7 @@ func (s *Server) Delete(rw http.ResponseWriter, req *http.Request) {
 func (s *Server) List(rw http.ResponseWriter, req *http.Request) {
 	configs := []discovery.StaticConfig{}
 	resp := v0.ListResponse{}
-	hosts, err := s.dnsTracker.List()
+	hosts, ports, err := s.dnsTracker.List()
 	if err != nil {
 		resp.Error = &v2.Error{
 			Type:   "list",
@@ -325,8 +325,7 @@ func (s *Server) List(rw http.ResponseWriter, req *http.Request) {
 
 	// Create a prometheus StaticConfig for each known host.
 	for i := range hosts {
-		// TODO(soltesz): record/lookup monitoring ports in memorystore during register.
-		for _, port := range []string{"9990", "9991", "9992", "9993"} {
+		for _, port := range ports[i] {
 			// We create one record per host to add a unique "machine" label to each one.
 			configs = append(configs, discovery.StaticConfig{
 				Targets: []string{hosts[i] + ":" + port},
@@ -474,4 +473,25 @@ func getProbability(req *http.Request) float64 {
 		return 1.0
 	}
 	return p
+}
+
+func getPorts(req *http.Request) []string {
+	result := []string{}
+	ports := req.URL.Query()["ports"]
+	if len(ports) == 0 {
+		return []string{"9990"} // default port
+	}
+	for _, port := range ports {
+		// Verify this is a valid number.
+		_, err := strconv.ParseInt(port, 10, 64)
+		if err != nil {
+			// Skip if not.
+			continue
+		}
+		result = append(result, port)
+	}
+	if len(result) == 0 {
+		return []string{"9990"} // default port
+	}
+	return result
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -325,16 +325,19 @@ func (s *Server) List(rw http.ResponseWriter, req *http.Request) {
 
 	// Create a prometheus StaticConfig for each known host.
 	for i := range hosts {
-		// We create one record per host to add a unique "machine" label to each one.
-		configs = append(configs, discovery.StaticConfig{
-			Targets: []string{hosts[i]},
-			Labels: map[string]string{
-				"machine":    hosts[i],
-				"type":       "virtual",
-				"deployment": "byos",
-				"managed":    "none",
-			},
-		})
+		// TODO(soltesz): record/lookup monitoring ports in memorystore during register.
+		for _, port := range []string{"9990", "9991", "9992", "9993"} {
+			// We create one record per host to add a unique "machine" label to each one.
+			configs = append(configs, discovery.StaticConfig{
+				Targets: []string{hosts[i] + ":" + port},
+				Labels: map[string]string{
+					"machine":    hosts[i],
+					"type":       "virtual",
+					"deployment": "byos",
+					"managed":    "none",
+				},
+			})
+		}
 	}
 
 	var results interface{}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -80,10 +80,11 @@ type fakeStatusTracker struct {
 	updateErr error
 	deleteErr error
 	nodes     []string
+	ports     [][]string
 	listErr   error
 }
 
-func (f *fakeStatusTracker) Update(string) error {
+func (f *fakeStatusTracker) Update(string, []string) error {
 	return f.updateErr
 }
 
@@ -91,8 +92,8 @@ func (f *fakeStatusTracker) Delete(string) error {
 	return f.deleteErr
 }
 
-func (f *fakeStatusTracker) List() ([]string, error) {
-	return f.nodes, f.listErr
+func (f *fakeStatusTracker) List() ([]string, [][]string, error) {
+	return f.nodes, f.ports, f.listErr
 }
 
 func TestServer_Lookup(t *testing.T) {
@@ -323,7 +324,7 @@ func TestServer_Register(t *testing.T) {
 	}{
 		{
 			name:     "success",
-			params:   "?service=foo&organization=bar&iata=lga&ipv4=192.168.0.1&probability=1.0",
+			params:   "?service=foo&organization=bar&iata=lga&ipv4=192.168.0.1&probability=1.0&ports=9990",
 			Iata:     iataFinder,
 			Maxmind:  maxmind,
 			ASN:      fakeASN,
@@ -333,8 +334,8 @@ func TestServer_Register(t *testing.T) {
 			wantCode: http.StatusOK,
 		},
 		{
-			name:     "success-probability-invalid",
-			params:   "?service=foo&organization=bar&iata=lga&ipv4=192.168.0.1&probability=invalid",
+			name:     "success-probability-invalid-ports-invalid",
+			params:   "?service=foo&organization=bar&iata=lga&ipv4=192.168.0.1&probability=invalid&ports=invalid",
 			Iata:     iataFinder,
 			Maxmind:  maxmind,
 			ASN:      fakeASN,
@@ -513,18 +514,30 @@ func TestServer_List(t *testing.T) {
 			params: "",
 			lister: &fakeStatusTracker{
 				nodes: []string{"test1"},
+				ports: [][]string{{"9990", "9991"}},
 			},
 			wantCode:   http.StatusOK,
-			wantLength: 4,
+			wantLength: 2,
 		},
 		{
 			name:   "success-prometheus",
 			params: "?format=prometheus",
 			lister: &fakeStatusTracker{
 				nodes: []string{"test1"},
+				ports: [][]string{{"9990"}},
 			},
 			wantCode:   http.StatusOK,
-			wantLength: 4,
+			wantLength: 1,
+		},
+		{
+			name:   "success-prometheus",
+			params: "?format=prometheus",
+			lister: &fakeStatusTracker{
+				nodes: []string{"test1"},
+				ports: [][]string{[]string{}},
+			},
+			wantCode:   http.StatusOK,
+			wantLength: 0,
 		},
 		{
 			name:   "error-internal",
@@ -537,7 +550,6 @@ func TestServer_List(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// 	Nodes:   tt.fields.Nodes,
 			s := NewServer("mlab-sandbox", nil, nil, nil, nil, tt.lister)
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/autojoin/v0/node/list"+tt.params, nil)

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -515,7 +515,7 @@ func TestServer_List(t *testing.T) {
 				nodes: []string{"test1"},
 			},
 			wantCode:   http.StatusOK,
-			wantLength: 1,
+			wantLength: 4,
 		},
 		{
 			name:   "success-prometheus",
@@ -524,7 +524,7 @@ func TestServer_List(t *testing.T) {
 				nodes: []string{"test1"},
 			},
 			wantCode:   http.StatusOK,
-			wantLength: 1,
+			wantLength: 4,
 		},
 		{
 			name:   "error-internal",

--- a/internal/tracker/gc_test.go
+++ b/internal/tracker/gc_test.go
@@ -83,7 +83,7 @@ func TestGarbageCollector_Update(t *testing.T) {
 	fakeMSClient := &fakeMemorystoreClient[Status]{}
 	gc := NewGarbageCollector(dns, "test-project", fakeMSClient, 3*time.Hour, 1*time.Hour)
 
-	err := gc.Update("foo-lga12345-c0a80001.bar.sandbox.measurement-lab.org")
+	err := gc.Update("foo-lga12345-c0a80001.bar.sandbox.measurement-lab.org", nil)
 	if err != nil {
 		t.Errorf("Update() returned err, expected nil: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestGarbageCollector_List(t *testing.T) {
 
 	// Inject error into GetAll
 	fakeMSClient.getErr = errors.New("fake getall error")
-	_, err := gc.List()
+	_, _, err := gc.List()
 	if err != fakeMSClient.getErr {
 		t.Errorf("List() failed for unexpected reason; got %v; want %v", err, fakeMSClient.getErr)
 	}


### PR DESCRIPTION
This change adds a new flag to `register`, stores given ports in memorystore via the `DNSRecord` structure, and uses these ports to generate monitoring targets in `List`.

This functionality will make it possible for Prometheus to get a list of knowns nodes with monitoring ports and scrape metrics from BYOS nodes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/32)
<!-- Reviewable:end -->
