### PR TITLE
Change network from "locate" to "autojoin"

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -16,7 +16,7 @@ resources:
 
 network:
   # TODO(soltesz): setup monitoring for production (in mlab-autojoin).
-  name: locate
+  name: autojoin
   forwarded_ports:
     - 9090/tcp
 

--- a/app.yaml
+++ b/app.yaml
@@ -17,7 +17,7 @@ resources:
 network:
   # TODO(soltesz): setup monitoring for production (in mlab-autojoin).
   name: autojoin
-  subnetwork_name: autojoin
+  subnetwork_name: gae
   forwarded_ports:
     - 9090/tcp
 

--- a/app.yaml
+++ b/app.yaml
@@ -17,6 +17,7 @@ resources:
 network:
   # TODO(soltesz): setup monitoring for production (in mlab-autojoin).
   name: autojoin
+  subnetwork_name: autojoin
   forwarded_ports:
     - 9090/tcp
 


### PR DESCRIPTION
The new autojoin network is dedicated to the Autojoin API and its associated Redis instance (see https://github.com/m-lab/terraform-support/pull/93)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/33)
<!-- Reviewable:end -->
