### PR TITLE
Check that the ipv4 address is actually v4

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -164,10 +164,10 @@ func (s *Server) Register(rw http.ResponseWriter, req *http.Request) {
 	param.IPv6 = checkIP(req.URL.Query().Get("ipv6")) // optional.
 	param.IPv4 = checkIP(getClientIP(req))
 	ip := net.ParseIP(param.IPv4)
-	if ip == nil {
+	if ip == nil || ip.To4() == nil {
 		resp.Error = &v2.Error{
 			Type:   "?ipv4=<ipv4>",
-			Title:  "could not determine client ip from request",
+			Title:  "could not determine client ipv4 from request",
 			Status: http.StatusBadRequest,
 		}
 		rw.WriteHeader(resp.Error.Status)


### PR DESCRIPTION
This fixes a bug where the autojoin API would fail creating the right hostname and DNS records when the registration request comes over IPv6, treating it as an IPv4. e.g.:

```2024-08-21 21:04:49 autojoin[20240821t195345]  /workspace/handler/handler.go:227: dns register failure: googleapi: Error 400: Invalid value for 'entity.change.additions[ndt-oma0-.mlab.autojoin.measurement-lab.org.][A].rrdata[0]': '2600:1900:4000:7927::', invalid```

Possible scenarios:
1. The request comes over IPv4, without `ipv4` in the querystring: the client's IP address is only accepted if it's a valid v4 address
2. The request comes over IPv4, with `ipv4` in the querystring: the ipv4 in the querystring takes precedence. For example, the default route on the node might not use the same interface the host wants to use to serve NDT
3. The request comes over IPv6, without `ipv4` in the querystring: this fails, since there is no way for Autojoin API to know the node's IPv4
4. The request comes over IPv6, with `ipv4` in the querystring: the ipv4 in the querystring is used, no ipv6 is set. Noting that this makes it mandatory for the host to provide an ipv6 if they want to serve tests over ipv6.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/35)
<!-- Reviewable:end -->
