### PR TITLE
Add node org to monitoring labels

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -325,6 +325,10 @@ func (s *Server) List(rw http.ResponseWriter, req *http.Request) {
 
 	// Create a prometheus StaticConfig for each known host.
 	for i := range hosts {
+		h, err := host.Parse(hosts[i])
+		if err != nil {
+			continue
+		}
 		for _, port := range ports[i] {
 			// We create one record per host to add a unique "machine" label to each one.
 			configs = append(configs, discovery.StaticConfig{
@@ -334,6 +338,7 @@ func (s *Server) List(rw http.ResponseWriter, req *http.Request) {
 					"type":       "virtual",
 					"deployment": "byos",
 					"managed":    "none",
+					"org":        h.Org,
 				},
 			})
 		}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -513,7 +513,8 @@ func TestServer_List(t *testing.T) {
 			name:   "success",
 			params: "",
 			lister: &fakeStatusTracker{
-				nodes: []string{"test1"},
+				// Fake node name must parse correctly.
+				nodes: []string{"ndt-lga3356-040e9f4b.mlab.autojoin.measurement-lab.org"},
 				ports: [][]string{{"9990", "9991"}},
 			},
 			wantCode:   http.StatusOK,
@@ -523,7 +524,7 @@ func TestServer_List(t *testing.T) {
 			name:   "success-prometheus",
 			params: "?format=prometheus",
 			lister: &fakeStatusTracker{
-				nodes: []string{"test1"},
+				nodes: []string{"ndt-lga3356-040e9f4b.mlab.autojoin.measurement-lab.org"},
 				ports: [][]string{{"9990"}},
 			},
 			wantCode:   http.StatusOK,


### PR DESCRIPTION
This change adds an "org" label to monitored autojoined nodes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/36)
<!-- Reviewable:end -->
