### PR TITLE
Add adminx package for naming resources

### DIFF
--- a/internal/adminx/namer.go
+++ b/internal/adminx/namer.go
@@ -10,36 +10,36 @@ func NewNamer(proj string) *Namer {
 	return &Namer{Project: proj}
 }
 
-// GetProjectsPrefix returns a google could project resource name,
+// GetProjectsPrefix returns a google cloud project resource name,
 // e.g. projects/mlab-foo
 func (n *Namer) GetProjectsName() string {
 	return "projects/" + n.Project
 }
 
-// GetServiceAccountID returns a service account ID for this org, e.g. autonode-gcsrw-org.
+// GetServiceAccountID returns a service account ID for this org, e.g. autonode-org.
 func (n *Namer) GetServiceAccountID(org string) string {
-	return "autonode-gcsrw-" + org
+	return "autonode-" + org
 }
 
 // GetServiceAccountEmail returns a service account email for this org, e.g.
-// autonode-gcsrw-org@mlab-foo.iam.gserviceaccount.com
+// autonode-org@mlab-foo.iam.gserviceaccount.com
 func (n *Namer) GetServiceAccountEmail(org string) string {
 	return n.GetServiceAccountID(org) + "@" + n.Project + ".iam.gserviceaccount.com"
 }
 
 // GetServiceAccountName returns a google cloud service account resource name,
-// e.g. projects/mlab-foo/serviceAccounts/autonode-gcsrw-foo@mlab-foo.iam.gserviceaccount.com
+// e.g. projects/mlab-foo/serviceAccounts/autonode-foo@mlab-foo.iam.gserviceaccount.com
 func (n *Namer) GetServiceAccountName(org string) string {
 	return n.GetProjectsName() + "/serviceAccounts/" + n.GetServiceAccountEmail(org)
 }
 
-// GetSecretID returns a secret ID for this org, e.g. autojoin-secret-org.
+// GetSecretID returns a secret ID for this org, e.g. autojoin-sa-key-org.
 func (n *Namer) GetSecretID(org string) string {
-	return "autojoin-secret-" + org
+	return "autojoin-sa-key-" + org
 }
 
 // GetSecretName returns the google cloud secret resource name, e.g.
-// projects/mlab-foo/secrets/autojoin-secret-org
+// projects/mlab-foo/secrets/autojoin-sa-key-org
 func (n *Namer) GetSecretName(org string) string {
 	return n.GetProjectsName() + "/secrets/" + n.GetSecretID(org)
 }

--- a/internal/adminx/namer.go
+++ b/internal/adminx/namer.go
@@ -33,13 +33,13 @@ func (n *Namer) GetServiceAccountName(org string) string {
 	return n.GetProjectsName() + "/serviceAccounts/" + n.GetServiceAccountEmail(org)
 }
 
-// GetSecretID returns a secret ID for this org, e.g. autojoin-sa-key-org.
+// GetSecretID returns a secret ID for this org, e.g. autojoin-serviceaccount-key-org.
 func (n *Namer) GetSecretID(org string) string {
-	return "autojoin-sa-key-" + org
+	return "autojoin-serviceaccount-key-" + org
 }
 
 // GetSecretName returns the google cloud secret resource name, e.g.
-// projects/mlab-foo/secrets/autojoin-sa-key-org
+// projects/mlab-foo/secrets/autojoin-serviceaccount-key-org
 func (n *Namer) GetSecretName(org string) string {
 	return n.GetProjectsName() + "/secrets/" + n.GetSecretID(org)
 }

--- a/internal/adminx/namer.go
+++ b/internal/adminx/namer.go
@@ -1,0 +1,45 @@
+package adminx
+
+// Namer contains metadata needed for resource naming.
+type Namer struct {
+	Project string
+}
+
+// NewNamer creates a new Namer instance for the given project.
+func NewNamer(proj string) *Namer {
+	return &Namer{Project: proj}
+}
+
+// GetProjectsPrefix returns a google could project resource name,
+// e.g. projects/mlab-foo
+func (n *Namer) GetProjectsName() string {
+	return "projects/" + n.Project
+}
+
+// GetServiceAccountID returns a service account ID for this org, e.g. autonode-gcsrw-org.
+func (n *Namer) GetServiceAccountID(org string) string {
+	return "autonode-gcsrw-" + org
+}
+
+// GetServiceAccountEmail returns a service account email for this org, e.g.
+// autonode-gcsrw-org@mlab-foo.iam.gserviceaccount.com
+func (n *Namer) GetServiceAccountEmail(org string) string {
+	return n.GetServiceAccountID(org) + "@" + n.Project + ".iam.gserviceaccount.com"
+}
+
+// GetServiceAccountName returns a google cloud service account resource name,
+// e.g. projects/mlab-foo/serviceAccounts/autonode-gcsrw-foo@mlab-foo.iam.gserviceaccount.com
+func (n *Namer) GetServiceAccountName(org string) string {
+	return n.GetProjectsName() + "/serviceAccounts/" + n.GetServiceAccountEmail(org)
+}
+
+// GetSecretID returns a secret ID for this org, e.g. autojoin-secret-org.
+func (n *Namer) GetSecretID(org string) string {
+	return "autojoin-secret-" + org
+}
+
+// GetSecretName returns the google cloud secret resource name, e.g.
+// projects/mlab-foo/secrets/autojoin-secret-org
+func (n *Namer) GetSecretName(org string) string {
+	return n.GetProjectsName() + "/secrets/" + n.GetSecretID(org)
+}

--- a/internal/adminx/namer_test.go
+++ b/internal/adminx/namer_test.go
@@ -22,8 +22,8 @@ func TestNamer_GetProjectsName(t *testing.T) {
 			wantSAID:    "autonode-foo",
 			wantSAEmail: "autonode-foo@mlab-sandbox.iam.gserviceaccount.com",
 			wantSAName:  "projects/mlab-sandbox/serviceAccounts/autonode-foo@mlab-sandbox.iam.gserviceaccount.com",
-			wantSecID:   "autojoin-sa-key-foo",
-			wantSecName: "projects/mlab-sandbox/secrets/autojoin-sa-key-foo",
+			wantSecID:   "autojoin-serviceaccount-key-foo",
+			wantSecName: "projects/mlab-sandbox/secrets/autojoin-serviceaccount-key-foo",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/adminx/namer_test.go
+++ b/internal/adminx/namer_test.go
@@ -1,0 +1,52 @@
+package adminx
+
+import "testing"
+
+func TestNamer_GetProjectsName(t *testing.T) {
+	tests := []struct {
+		name        string
+		proj        string
+		org         string
+		wantProject string
+		wantSAID    string
+		wantSAEmail string
+		wantSAName  string
+		wantSecID   string
+		wantSecName string
+	}{
+		{
+			name:        "success",
+			proj:        "mlab-sandbox",
+			org:         "foo",
+			wantProject: "projects/mlab-sandbox",
+			wantSAID:    "autonode-gcsrw-foo",
+			wantSAEmail: "autonode-gcsrw-foo@mlab-sandbox.iam.gserviceaccount.com",
+			wantSAName:  "projects/mlab-sandbox/serviceAccounts/autonode-gcsrw-foo@mlab-sandbox.iam.gserviceaccount.com",
+			wantSecID:   "autojoin-secret-foo",
+			wantSecName: "projects/mlab-sandbox/secrets/autojoin-secret-foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := NewNamer(tt.proj)
+			if got := n.GetProjectsName(); got != tt.wantProject {
+				t.Errorf("Namer.GetProjectsName() = %v, want %v", got, tt.wantProject)
+			}
+			if got := n.GetServiceAccountID(tt.org); got != tt.wantSAID {
+				t.Errorf("Namer.GetServiceAccountID() = %v, want %v", got, tt.wantSAID)
+			}
+			if got := n.GetServiceAccountEmail(tt.org); got != tt.wantSAEmail {
+				t.Errorf("Namer.GetServiceAccountEmail() = %v, want %v", got, tt.wantSAEmail)
+			}
+			if got := n.GetServiceAccountName(tt.org); got != tt.wantSAName {
+				t.Errorf("Namer.GetServiceAccountName() = %v, want %v", got, tt.wantSAName)
+			}
+			if got := n.GetSecretID(tt.org); got != tt.wantSecID {
+				t.Errorf("Namer.GetSecretID() = %v, want %v", got, tt.wantSecID)
+			}
+			if got := n.GetSecretName(tt.org); got != tt.wantSecName {
+				t.Errorf("Namer.GetSecretName() = %v, want %v", got, tt.wantSecName)
+			}
+		})
+	}
+}

--- a/internal/adminx/namer_test.go
+++ b/internal/adminx/namer_test.go
@@ -19,11 +19,11 @@ func TestNamer_GetProjectsName(t *testing.T) {
 			proj:        "mlab-sandbox",
 			org:         "foo",
 			wantProject: "projects/mlab-sandbox",
-			wantSAID:    "autonode-gcsrw-foo",
-			wantSAEmail: "autonode-gcsrw-foo@mlab-sandbox.iam.gserviceaccount.com",
-			wantSAName:  "projects/mlab-sandbox/serviceAccounts/autonode-gcsrw-foo@mlab-sandbox.iam.gserviceaccount.com",
-			wantSecID:   "autojoin-secret-foo",
-			wantSecName: "projects/mlab-sandbox/secrets/autojoin-secret-foo",
+			wantSAID:    "autonode-foo",
+			wantSAEmail: "autonode-foo@mlab-sandbox.iam.gserviceaccount.com",
+			wantSAName:  "projects/mlab-sandbox/serviceAccounts/autonode-foo@mlab-sandbox.iam.gserviceaccount.com",
+			wantSecID:   "autojoin-sa-key-foo",
+			wantSecName: "projects/mlab-sandbox/secrets/autojoin-sa-key-foo",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This change adds a new package `adminx` with the first of several types needed to manage service accounts and secrets within GCP for the autojoin API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/37)
<!-- Reviewable:end -->
