### PR TITLE
Add service account key to Register API response

### DIFF
--- a/api/v0/api.go
+++ b/api/v0/api.go
@@ -48,6 +48,13 @@ type ServerAnnotation struct {
 	Type       string
 }
 
+// Credentials contains data for the node to authorize or validate operations.
+type Credentials struct {
+	// ServiceAccountKey contains the base64 encoded service account key for use
+	// by the registered node.
+	ServiceAccountKey string
+}
+
 // Registration is returned for a successful registration request.
 type Registration struct {
 	// Hostname is the dynamic DNS name. Hostname should be available immediately.
@@ -57,4 +64,7 @@ type Registration struct {
 	Annotation *ServerAnnotation `json:",omitempty"`
 	// Heartbeat is the registration message used by the heartbeat service to register with the Locate API.
 	Heartbeat *v2.Registration `json:",omitempty"`
+
+	// Credentials contains node key data.
+	Credentials *Credentials `json:",omitempty"`
 }

--- a/api/v0/api.go
+++ b/api/v0/api.go
@@ -48,10 +48,10 @@ type ServerAnnotation struct {
 	Type       string
 }
 
-// Credentials contains data for the node to authorize or validate operations.
+// Credentials contains public or private key data needed for node operations.
 type Credentials struct {
 	// ServiceAccountKey contains the base64 encoded service account key for use
-	// by the registered node.
+	// by the node after registration.
 	ServiceAccountKey string
 }
 

--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -23,10 +24,11 @@ import (
 )
 
 const (
-	registerEndpoint   = "https://autojoin-dot-mlab-sandbox.appspot.com/autojoin/v0/node/register"
-	heartbeatFilename  = "registration.json"
-	annotationFilename = "annotation.json"
-	hostnameFilename   = "hostname"
+	registerEndpoint       = "https://autojoin-dot-mlab-sandbox.appspot.com/autojoin/v0/node/register"
+	heartbeatFilename      = "registration.json"
+	annotationFilename     = "annotation.json"
+	serviceAccountFilename = "service-account-autojoin.json"
+	hostnameFilename       = "hostname"
 )
 
 var (
@@ -146,6 +148,14 @@ func register() {
 	rtx.Must(err, "Failed to write heartbeat file")
 	err = os.WriteFile(path.Join(*outputPath, annotationFilename), annotationJSON, 0644)
 	rtx.Must(err, "Failed to write annotation file")
+
+	// Service account credentials.
+	if r.Registration.Credentials != nil {
+		key, err := base64.StdEncoding.DecodeString(r.Registration.Credentials.ServiceAccountKey)
+		rtx.Must(err, "Failed to decode service account key")
+		err = os.WriteFile(path.Join(*outputPath, serviceAccountFilename), key, 0644)
+		rtx.Must(err, "Failed to write annotation file")
+	}
 
 	log.Printf("Registration successful with hostname: %s", r.Registration.Hostname)
 	registerSuccess.Store(true)

--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -151,6 +151,7 @@ func register() {
 
 	// Service account credentials.
 	if r.Registration.Credentials != nil {
+		// TODO(soltesz): abort on nil after deployment.
 		key, err := base64.StdEncoding.DecodeString(r.Registration.Credentials.ServiceAccountKey)
 		rtx.Must(err, "Failed to decode service account key")
 		err = os.WriteFile(path.Join(*outputPath, serviceAccountFilename), key, 0644)

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -40,7 +40,7 @@ type Server struct {
 	ASN     ASNFinder
 	DNS     dnsiface.Service
 
-	sm         SecretManager
+	sm         ServiceAccountSecretManager
 	dnsTracker DNSTracker
 }
 
@@ -69,13 +69,14 @@ type DNSTracker interface {
 	List() ([]string, [][]string, error)
 }
 
-type SecretManager interface {
+// ServiceAccountSecretManager is an interface used by the server to allocate service account keys.
+type ServiceAccountSecretManager interface {
 	LoadOrCreateKey(ctx context.Context, org string) (string, error)
 }
 
 // NewServer creates a new Server instance for request handling.
 func NewServer(project string, finder IataFinder, maxmind MaxmindFinder, asn ASNFinder,
-	ds dnsiface.Service, tracker DNSTracker, sm SecretManager) *Server {
+	ds dnsiface.Service, tracker DNSTracker, sm ServiceAccountSecretManager) *Server {
 	return &Server{
 		Project: project,
 		Iata:    finder,

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -328,7 +328,7 @@ func TestServer_Register(t *testing.T) {
 		ASN      ASNFinder
 		DNS      dnsiface.Service
 		Tracker  DNSTracker
-		sm       SecretManager
+		sm       ServiceAccountSecretManager
 		params   string
 		wantName string
 		wantCode int

--- a/main.go
+++ b/main.go
@@ -7,9 +7,12 @@ import (
 	"net/http"
 	"time"
 
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"github.com/gomodule/redigo/redis"
 	"github.com/m-lab/autojoin/handler"
 	"github.com/m-lab/autojoin/iata"
+	"github.com/m-lab/autojoin/internal/adminx"
+	"github.com/m-lab/autojoin/internal/adminx/iamiface"
 	"github.com/m-lab/autojoin/internal/dnsx/dnsiface"
 	"github.com/m-lab/autojoin/internal/maxmind"
 	"github.com/m-lab/autojoin/internal/tracker"
@@ -25,6 +28,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/api/dns/v1"
+	"google.golang.org/api/iam/v1"
 )
 
 var (
@@ -88,6 +92,17 @@ func main() {
 	rtx.Must(err, "Could not load routeview v4 URL")
 	asn := asnannotator.NewIPv4(mainCtx, rvsrc)
 
+	// Secret Manager & Service Accounts
+	sc, err := secretmanager.NewClient(mainCtx)
+	rtx.Must(err, "failed to create secretmanager client")
+	defer sc.Close()
+	ic, err := iam.NewService(mainCtx)
+	rtx.Must(err, "failed to create iam service client")
+	n := adminx.NewNamer(project)
+	sa := adminx.NewServiceAccountsManager(iamiface.NewIAM(ic), n)
+	rtx.Must(err, "failed to create sam")
+	sm := adminx.NewSecretManager(sc, n, sa)
+
 	// Connect to memorystore.
 	pool := &redis.Pool{
 		Dial: func() (redis.Conn, error) {
@@ -107,7 +122,7 @@ func main() {
 	defer gc.Stop()
 
 	// Create server.
-	s := handler.NewServer(project, i, mm, asn, d, gc)
+	s := handler.NewServer(project, i, mm, asn, d, gc, sm)
 	go func() {
 		// Load once.
 		s.Iata.Load(mainCtx)

--- a/main.go
+++ b/main.go
@@ -100,7 +100,6 @@ func main() {
 	rtx.Must(err, "failed to create iam service client")
 	n := adminx.NewNamer(project)
 	sa := adminx.NewServiceAccountsManager(iamiface.NewIAM(ic), n)
-	rtx.Must(err, "failed to create sam")
 	sm := adminx.NewSecretManager(sc, n, sa)
 
 	// Connect to memorystore.


### PR DESCRIPTION
This change adds a new field to the `v0.RegisterResponse` structure for `Credentials`. The first field of this structure is the `ServiceAccountKey` which will be base64 encoded, as it is returned from the IAM CreateKey API.

This change includes updates to the Register handler, and setup for the Server structure in the autojoin main.go setup. Finally, this change includes updates to the `register` command to save the service account credentials to a local file.

The combination of these changes should make it easier to deploy new organizations without out-of-band credential management.

TODO: add command to setup new organizations which ensureas that the service account and secrets exist before Register is called.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/40)
<!-- Reviewable:end -->
