### PR TITLE
Add orgadm for new organization setup

### DIFF
--- a/cmd/orgadm/main.go
+++ b/cmd/orgadm/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"github.com/m-lab/autojoin/internal/adminx"
+	"github.com/m-lab/autojoin/internal/adminx/crmiface"
+	"github.com/m-lab/autojoin/internal/adminx/iamiface"
+	"github.com/m-lab/go/rtx"
+	"google.golang.org/api/cloudresourcemanager/v1"
+	iam "google.golang.org/api/iam/v1"
+)
+
+var (
+	org     string
+	project string
+)
+
+func init() {
+	flag.StringVar(&org, "org", "", "Organization name. Must match name assigned by M-Lab")
+	flag.StringVar(&project, "project", "", "GCP project to create organization resources")
+}
+
+func main() {
+	flag.Parse()
+	log.SetFlags(log.Lshortfile | log.LUTC)
+
+	if org == "" || project == "" {
+		log.Fatalf("-org and -project are required flags")
+	}
+
+	ctx := context.Background()
+	sc, err := secretmanager.NewClient(ctx)
+	rtx.Must(err, "failed to create secretmanager client")
+	defer sc.Close()
+	ic, err := iam.NewService(ctx)
+	rtx.Must(err, "failed to create iam service client")
+	log.Println("Creating SAM & KEYS")
+	nn := adminx.NewNamer(project)
+	crm, err := cloudresourcemanager.NewService(ctx)
+	rtx.Must(err, "failed to allocate new cloud resource manager client")
+	sa := adminx.NewServiceAccountsManager(iamiface.NewIAM(ic), nn)
+	rtx.Must(err, "failed to create sam")
+	sm := adminx.NewSecretManager(sc, nn, sa)
+	o := adminx.NewOrg(project, crmiface.NewCRM(project, crm), sa, sm)
+	o.Setup(ctx, org)
+}

--- a/internal/adminx/crmiface/crm.go
+++ b/internal/adminx/crmiface/crm.go
@@ -1,0 +1,29 @@
+package crmiface
+
+import (
+	"context"
+
+	"google.golang.org/api/cloudresourcemanager/v1"
+)
+
+type crmImpl struct {
+	crm     *cloudresourcemanager.Service
+	Project string
+}
+
+// NewCRM creates a new crm implementation for wrapping the cloudresourcemanager.Service.
+func NewCRM(project string, crm *cloudresourcemanager.Service) *crmImpl {
+	return &crmImpl{
+		Project: project,
+		crm:     crm,
+	}
+}
+
+func (c *crmImpl) GetIamPolicy(ctx context.Context, req *cloudresourcemanager.GetIamPolicyRequest) (*cloudresourcemanager.Policy, error) {
+	return c.crm.Projects.GetIamPolicy(c.Project, req).Context(ctx).Do()
+}
+
+func (c *crmImpl) SetIamPolicy(ctx context.Context, req *cloudresourcemanager.SetIamPolicyRequest) error {
+	_, err := c.crm.Projects.SetIamPolicy(c.Project, req).Context(ctx).Do()
+	return err
+}

--- a/internal/adminx/org.go
+++ b/internal/adminx/org.go
@@ -127,7 +127,7 @@ func appendBindingIfMissing(slice []*cloudresourcemanager.Binding, elems ...*clo
 		found := false
 		// Does slice contain B?
 		for _, a := range slice {
-			if bindingIsEqual(a, b) {
+			if BindingIsEqual(a, b) {
 				// We found a matching binding.
 				found = true
 				break
@@ -143,7 +143,8 @@ func appendBindingIfMissing(slice []*cloudresourcemanager.Binding, elems ...*clo
 	return append(result, slice...), foundMissing
 }
 
-func bindingIsEqual(a *cloudresourcemanager.Binding, b *cloudresourcemanager.Binding) bool {
+// BindingIsEqual checks wether the two provided bindings contain equal conditions, members, and roles.
+func BindingIsEqual(a *cloudresourcemanager.Binding, b *cloudresourcemanager.Binding) bool {
 	if (a.Condition != nil) != (b.Condition != nil) {
 		// Either both should have conditions or neither.
 		return false

--- a/internal/adminx/org.go
+++ b/internal/adminx/org.go
@@ -1,0 +1,173 @@
+package adminx
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"golang.org/x/exp/slices"
+
+	"google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/iam/v1"
+)
+
+var (
+	// Restrict uploads to the organization prefix. Needed to share bucket write access.
+	expUploadFmt = (`resource.name.startsWith("projects/_/buckets/archive-%s/objects/autoload/v2/%s") ||` +
+		` resource.name.startsWith("projects/_/buckets/staging-%s/objects/autoload/v2/%s")`)
+	// Restrict reads to the archive bucket. Needed so nodes can read jostler schemas.
+	expReadFmt = (`resource.name.startsWith("projects/_/buckets/archive-%s") ||` +
+		` resource.name.startsWith("projects/_/buckets/staging-%s")`)
+)
+
+// CRM is a simplified interface to the Google Cloud Resource Manager API.
+type CRM interface {
+	GetIamPolicy(ctx context.Context, req *cloudresourcemanager.GetIamPolicyRequest) (*cloudresourcemanager.Policy, error)
+	SetIamPolicy(ctx context.Context, req *cloudresourcemanager.SetIamPolicyRequest) error
+}
+
+// Org contains fields needed to setup a new organization for Autojoined nodes.
+type Org struct {
+	Project string
+	crm     CRM
+	sam     *ServiceAccountsManager
+	sm      *SecretManager
+}
+
+// NewOrg creates a new Org instance for setting up a new organization.
+func NewOrg(project string, crm CRM, sam *ServiceAccountsManager, sm *SecretManager) *Org {
+	return &Org{
+		Project: project,
+		crm:     crm,
+		sam:     sam,
+		sm:      sm,
+	}
+}
+
+// Setup should be run once on org creation to create all Google Cloud resources needed by the Autojoin API.
+func (o *Org) Setup(ctx context.Context, org string) error {
+	// Create service account with no keys.
+	sa, err := o.sam.CreateServiceAccount(ctx, org)
+	if err != nil {
+		return err
+	}
+	err = o.ApplyPolicy(ctx, org, sa)
+	if err != nil {
+		return err
+	}
+	// Create secret with no versions.
+	err = o.sm.CreateSecret(ctx, org)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ApplyPolicy adds write restrictions for shared GCS buckets.
+// NOTE: By operating on project IAM policies, this method modifies project wide state.
+func (o *Org) ApplyPolicy(ctx context.Context, org string, account *iam.ServiceAccount) error {
+	// Get current policy.
+	req := &cloudresourcemanager.GetIamPolicyRequest{
+		Options: &cloudresourcemanager.GetPolicyOptions{
+			RequestedPolicyVersion: 3,
+		},
+	}
+	curr, err := o.crm.GetIamPolicy(ctx, req)
+	if err != nil {
+		log.Println("get policy", err)
+		return err
+	}
+	// Setup new bindings.
+	bindings := []*cloudresourcemanager.Binding{
+		{
+			Condition: &cloudresourcemanager.Expr{
+				Title:      "Upload restriction for " + org,
+				Expression: fmt.Sprintf(expUploadFmt, o.Project, org, o.Project, org),
+			},
+			Members: []string{"serviceAccount:" + account.Email},
+			Role:    "roles/storage.objectCreator",
+		},
+		{
+			Condition: &cloudresourcemanager.Expr{
+				Title:      "Read restriction for " + org,
+				Expression: fmt.Sprintf(expReadFmt, o.Project, o.Project),
+			},
+			Members: []string{"serviceAccount:" + account.Email},
+			Role:    "roles/storage.objectViewer",
+		},
+	}
+
+	// Append the new bindings if missing from the current set.
+	newBindings, wasMissing := appendBindingIfMissing(curr.Bindings, bindings...)
+
+	// Apply bindings if any were missing.
+	preq := &cloudresourcemanager.SetIamPolicyRequest{
+		Policy: &cloudresourcemanager.Policy{
+			AuditConfigs: curr.AuditConfigs,
+			Bindings:     newBindings,
+			Etag:         curr.Etag,
+			Version:      curr.Version,
+		},
+	}
+
+	if wasMissing {
+		err = o.crm.SetIamPolicy(ctx, preq)
+		if err != nil {
+			log.Println("set policy", err)
+			return err
+		}
+	}
+	return nil
+}
+
+func appendBindingIfMissing(slice []*cloudresourcemanager.Binding, elems ...*cloudresourcemanager.Binding) ([]*cloudresourcemanager.Binding, bool) {
+	result := []*cloudresourcemanager.Binding{}
+	foundMissing := false
+	for _, b := range elems {
+		found := false
+		// Does slice contain B?
+		for _, a := range slice {
+			if bindingIsEqual(a, b) {
+				// We found a matching binding.
+				found = true
+				break
+			}
+		}
+		if !found {
+			// slice does not contain B, so add it to results.
+			result = append(result, b)
+			foundMissing = true
+		}
+	}
+	// Return all bindings
+	return append(result, slice...), foundMissing
+}
+
+func bindingIsEqual(a *cloudresourcemanager.Binding, b *cloudresourcemanager.Binding) bool {
+	if (a.Condition != nil) != (b.Condition != nil) {
+		// Either both should have conditions or neither.
+		return false
+	}
+	if a.Condition != nil {
+		// We established above that both are non-nil.
+		if a.Condition.Expression != b.Condition.Expression {
+			// Expressions should match.
+			return false
+		}
+	}
+	// Check membership in both directions: are all members of a in b, and b in a?
+	for i := range a.Members {
+		if !slices.Contains(b.Members, a.Members[i]) {
+			// Each member in A should be found in B.
+			return false
+		}
+	}
+	for i := range b.Members {
+		if !slices.Contains(a.Members, b.Members[i]) {
+			// Each member in B should be found in A.
+			return false
+		}
+	}
+	// Roles should match.
+	return a.Role == b.Role
+}

--- a/internal/adminx/org_test.go
+++ b/internal/adminx/org_test.go
@@ -1,0 +1,231 @@
+package adminx
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"testing"
+
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/iam/v1"
+)
+
+func init() {
+	// Silence package logging during tests.
+	log.SetOutput(io.Discard)
+}
+
+type fakeCRM struct {
+	getPolicy    *cloudresourcemanager.Policy
+	getPolicyErr error
+	setPolicyErr error
+	bindingCount int
+}
+
+func (f *fakeCRM) GetIamPolicy(ctx context.Context, req *cloudresourcemanager.GetIamPolicyRequest) (*cloudresourcemanager.Policy, error) {
+	return f.getPolicy, f.getPolicyErr
+}
+
+func (f *fakeCRM) SetIamPolicy(ctx context.Context, req *cloudresourcemanager.SetIamPolicyRequest) error {
+	f.bindingCount = len(req.Policy.Bindings)
+	return f.setPolicyErr
+}
+
+func TestOrg_Setup(t *testing.T) {
+	tests := []struct {
+		name    string
+		project string
+		crm     CRM
+		sam     IAMService
+		smc     SecretManagerClient
+		org     string
+		wantErr bool
+	}{
+		{
+			name: "success",
+			crm: &fakeCRM{
+				getPolicy: &cloudresourcemanager.Policy{
+					Bindings: []*cloudresourcemanager.Binding{
+						{
+							Members: []string{"foo"},
+							Role:    "roles/fooWriter",
+						},
+					},
+				},
+			},
+			sam: &fakeIAMService{
+				getAcct: &iam.ServiceAccount{
+					Name: "foo",
+				},
+			},
+			smc: &fakeSMC{
+				getSec: &secretmanagerpb.Secret{Name: "okay"},
+			},
+		},
+		{
+			name: "success-equal-bindings",
+			crm: &fakeCRM{
+				getPolicy: &cloudresourcemanager.Policy{
+					Bindings: []*cloudresourcemanager.Binding{
+						{
+							Members: []string{"foo"},
+							Role:    "roles/fooWriter",
+						},
+						{
+							Condition: &cloudresourcemanager.Expr{
+								Expression: "resource.name.startsWith(\"projects/_/buckets/archive-mlab-foo/objects/autoload/v2/foobar\") || resource.name.startsWith(\"projects/_/buckets/staging-mlab-foo/objects/autoload/v2/foobar\")",
+								Title:      "Upload restriction for foobar",
+							},
+							Members: []string{"serviceAccount:"},
+							Role:    "roles/storage.objectCreator",
+						},
+					},
+				},
+			},
+			sam: &fakeIAMService{
+				getAcct: &iam.ServiceAccount{
+					Name: "foo",
+				},
+			},
+			smc: &fakeSMC{
+				getSec: &secretmanagerpb.Secret{Name: "okay"},
+			},
+		},
+		{
+			name: "error-create-service-account",
+			sam: &fakeIAMService{
+				getAcctErr: fmt.Errorf("fake error messages"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "error-create-secret",
+			crm: &fakeCRM{
+				getPolicy: &cloudresourcemanager.Policy{
+					Bindings: []*cloudresourcemanager.Binding{
+						{
+							Members: []string{"foo"},
+							Role:    "roles/fooWriter",
+						},
+					},
+				},
+			},
+			sam: &fakeIAMService{
+				getAcct: &iam.ServiceAccount{
+					Name: "foo",
+				},
+			},
+			smc: &fakeSMC{
+				getSecErr: fmt.Errorf("fake create secret error"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "error-getiam",
+			crm: &fakeCRM{
+				getPolicyErr: fmt.Errorf("fake get iam policy error"),
+			},
+			sam: &fakeIAMService{
+				getAcct: &iam.ServiceAccount{
+					Name: "foo",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error-setiam",
+			crm: &fakeCRM{
+				getPolicy: &cloudresourcemanager.Policy{
+					Bindings: []*cloudresourcemanager.Binding{
+						{
+							Members: []string{"foo"},
+							Role:    "roles/fooWriter",
+						},
+					},
+				},
+				setPolicyErr: fmt.Errorf("fake set iam policy error"),
+			},
+			sam: &fakeIAMService{
+				getAcct: &iam.ServiceAccount{
+					Name: "foo",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := NewNamer("mlab-foo")
+			sam := NewServiceAccountsManager(tt.sam, n)
+			sm := NewSecretManager(tt.smc, n, sam)
+			o := NewOrg("mlab-foo", tt.crm, sam, sm)
+			if err := o.Setup(context.Background(), "foobar"); (err != nil) != tt.wantErr {
+				t.Errorf("Org.Setup() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBindingIsEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a    *cloudresourcemanager.Binding
+		b    *cloudresourcemanager.Binding
+		want bool
+	}{
+		{
+			name: "equal",
+			a: &cloudresourcemanager.Binding{
+				Condition: &cloudresourcemanager.Expr{
+					Title:      "my condition",
+					Expression: "resource.name.startsWith(\"projects/_/buckets/archive-mlab-foo/objects/autoload/v2/foobar\")",
+				},
+				Members: []string{"a", "b"},
+				Role:    "roles/tests.fooWriter",
+			},
+			b: &cloudresourcemanager.Binding{
+				Condition: &cloudresourcemanager.Expr{
+					Title:      "my condition",
+					Expression: "resource.name.startsWith(\"projects/_/buckets/archive-mlab-foo/objects/autoload/v2/foobar\")",
+				},
+				Members: []string{"a", "b"},
+				Role:    "roles/tests.fooWriter",
+			},
+			want: true,
+		},
+		{
+			name: "a-missing-members-in-b",
+			a: &cloudresourcemanager.Binding{
+				Members: []string{"a"},
+				Role:    "roles/tests.fooWriter",
+			},
+			b: &cloudresourcemanager.Binding{
+				Members: []string{"a", "b", "c"},
+				Role:    "roles/tests.fooWriter",
+			},
+			want: false,
+		},
+		{
+			name: "a-missing-members-in-b",
+			a: &cloudresourcemanager.Binding{
+				Members: []string{"a", "b", "c"},
+				Role:    "roles/tests.fooWriter",
+			},
+			b: &cloudresourcemanager.Binding{
+				Members: []string{"a"},
+				Role:    "roles/tests.fooWriter",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BindingIsEqual(tt.a, tt.b); got != tt.want {
+				t.Errorf("BindingIsEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds a new type `adminx.Org` and command `orgadm` to setup a new organization. The setup includes creating service accounts with no keys and secrets with no versions. An organization should be setup once before the first node attempts to Register via the Autojoin API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/41)
<!-- Reviewable:end -->
