### PR TITLE
Update iata-icao dataset

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ var (
 	listenPort   string
 	project      string
 	redisAddr    string
-	iataSrc      = flagx.MustNewURL("https://raw.githubusercontent.com/ip2location/ip2location-iata-icao/1.0.10/iata-icao.csv")
+	iataSrc      = flagx.MustNewURL("https://raw.githubusercontent.com/ip2location/ip2location-iata-icao/1.0.21/iata-icao.csv")
 	maxmindSrc   = flagx.URL{}
 	routeviewSrc = flagx.URL{}
 	gcTTL        time.Duration


### PR DESCRIPTION
This change updates the iata dataset to the latest version, which includes common Brazilian international airports, GIG and GRU among others added in this version. These airports are preferred by the RNP deployments.

See: https://github.com/ip2location/ip2location-iata-icao/releases

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/46)
<!-- Reviewable:end -->
