### PR TITLE
Add downloader to gcs read condition

### DIFF
--- a/internal/adminx/org.go
+++ b/internal/adminx/org.go
@@ -19,7 +19,8 @@ var (
 		` resource.name.startsWith("projects/_/buckets/staging-%s/objects/autoload/v2/%s")`)
 	// Restrict reads to the archive bucket. Needed so nodes can read jostler schemas.
 	expReadFmt = (`resource.name.startsWith("projects/_/buckets/archive-%s") ||` +
-		` resource.name.startsWith("projects/_/buckets/staging-%s")`)
+		` resource.name.startsWith("projects/_/buckets/downloader-%s")` +
+		` resource.name.startsWith("projects/_/buckets/staging-%s") ||`)
 )
 
 // DNS is a simplified interface to the Google Cloud DNS API.


### PR DESCRIPTION
This change adds an additional condition to the autojoin service account to read from the downloader bucket. This is necessary for the uuid-annotator to load Maxmind data.