### PR TITLE
List support for known servers and script-exporter targets

### DIFF
--- a/api/v0/api.go
+++ b/api/v0/api.go
@@ -32,6 +32,7 @@ type DeleteResponse struct {
 type ListResponse struct {
 	Error        *v2.Error                `json:",omitempty"`
 	StaticConfig []discovery.StaticConfig `json:",omitempty"`
+	Servers      []string                 `json:",omitempty"`
 }
 
 // Network contains IPv4 and IPv6 addresses.

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -370,9 +370,13 @@ func (s *Server) List(rw http.ResponseWriter, req *http.Request) {
 
 	var results interface{}
 	format := req.URL.Query().Get("format")
-	if format == "prometheus" {
+	switch format {
+	case "prometheus":
 		results = configs
-	} else {
+	case "servers":
+		resp.Servers = hosts
+		results = resp
+	default:
 		// NOTE: default format is not valid for prometheus StaticConfig format.
 		resp.StaticConfig = configs
 		results = resp

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -367,16 +367,20 @@ func (s *Server) List(rw http.ResponseWriter, req *http.Request) {
 			ports[i] = p
 		}
 		for _, port := range ports[i] {
+			labels := map[string]string{
+				"machine":    hosts[i],
+				"type":       "virtual",
+				"deployment": "byos",
+				"managed":    "none",
+				"org":        h.Org,
+			}
+			if req.URL.Query().Get("service") != "" {
+				labels["service"] = req.URL.Query().Get("service")
+			}
 			// We create one record per host to add a unique "machine" label to each one.
 			configs = append(configs, discovery.StaticConfig{
 				Targets: []string{hosts[i] + port},
-				Labels: map[string]string{
-					"machine":    hosts[i],
-					"type":       "virtual",
-					"deployment": "byos",
-					"managed":    "none",
-					"org":        h.Org,
-				},
+				Labels:  labels,
 			})
 		}
 	}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -576,7 +576,7 @@ func TestServer_List(t *testing.T) {
 			params: "?format=prometheus",
 			lister: &fakeStatusTracker{
 				nodes: []string{"test1"},
-				ports: [][]string{[]string{}},
+				ports: [][]string{{}},
 			},
 			wantCode:   http.StatusOK,
 			wantLength: 0,
@@ -586,7 +586,17 @@ func TestServer_List(t *testing.T) {
 			params: "?format=servers",
 			lister: &fakeStatusTracker{
 				nodes: []string{"ndt-lga3356-040e9f4b.mlab.autojoin.measurement-lab.org"},
-				ports: [][]string{[]string{"9990"}},
+				ports: [][]string{{"9990"}},
+			},
+			wantCode:   http.StatusOK,
+			wantLength: 1,
+		},
+		{
+			name:   "success-script-exporter",
+			params: "?format=script-exporter",
+			lister: &fakeStatusTracker{
+				nodes: []string{"ndt-lga3356-040e9f4b.mlab.autojoin.measurement-lab.org"},
+				ports: [][]string{{"9990"}},
 			},
 			wantCode:   http.StatusOK,
 			wantLength: 1,
@@ -617,7 +627,7 @@ func TestServer_List(t *testing.T) {
 			raw := rw.Body.Bytes()
 			configs := []discovery.StaticConfig{}
 			length := 0
-			if strings.Contains(tt.params, "prometheus") {
+			if strings.Contains(tt.params, "prometheus") || strings.Contains(tt.params, "script-exporter") {
 				err = json.Unmarshal(raw, &configs)
 				length = len(configs)
 			} else if strings.Contains(tt.params, "servers") {

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -593,7 +593,7 @@ func TestServer_List(t *testing.T) {
 		},
 		{
 			name:   "success-script-exporter",
-			params: "?format=script-exporter",
+			params: "?format=script-exporter&service=ndt7_client_byos",
 			lister: &fakeStatusTracker{
 				nodes: []string{"ndt-lga3356-040e9f4b.mlab.autojoin.measurement-lab.org"},
 				ports: [][]string{{"9990"}},


### PR DESCRIPTION
This change adds two new formats to the Autojoin.List API
* `format=servers` generates a list of all servers known to the API
* `format=script-exporter` generates a configuration suitable for targeting the script-exporter

These changes will make it possible to add e2e testing for the byos nodes in sandbox and staging so some measurements are always targeting our development services.

These changes will make it possible to easily list/review all servers known to the Autojoin system.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/49)
<!-- Reviewable:end -->