### PR TITLE
Allow listing sites and filtering on org

### DIFF
--- a/api/v0/api.go
+++ b/api/v0/api.go
@@ -33,6 +33,7 @@ type ListResponse struct {
 	Error        *v2.Error                `json:",omitempty"`
 	StaticConfig []discovery.StaticConfig `json:",omitempty"`
 	Servers      []string                 `json:",omitempty"`
+	Sites        []string                 `json:",omitempty"`
 }
 
 // Network contains IPv4 and IPv6 addresses.

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -354,7 +354,7 @@ func (s *Server) List(rw http.ResponseWriter, req *http.Request) {
 
 	org := req.URL.Query().Get("org")
 	format := req.URL.Query().Get("format")
-	sites := []string{}
+	sites := map[string]bool{}
 
 	// Create a prometheus StaticConfig for each known host.
 	for i := range hosts {
@@ -366,7 +366,7 @@ func (s *Server) List(rw http.ResponseWriter, req *http.Request) {
 			// Skip hosts that are not part of the given org.
 			continue
 		}
-		sites = append(sites, h.Site)
+		sites[h.Site] = true
 		if format == "script-exporter" {
 			// NOTE: do not assign any ports for script exporter.
 			ports[i] = []string{""}
@@ -409,7 +409,9 @@ func (s *Server) List(rw http.ResponseWriter, req *http.Request) {
 		resp.Servers = hosts
 		results = resp
 	case "sites":
-		resp.Sites = sites
+		for k := range sites {
+			resp.Sites = append(resp.Sites, k)
+		}
 		results = resp
 	default:
 		// NOTE: default format is not valid for prometheus StaticConfig format.

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -331,6 +331,11 @@ func (s *Server) Delete(rw http.ResponseWriter, req *http.Request) {
 // List handler is used by monitoring to generate a list of known, active
 // hostnames previously registered with the Autojoin API.
 func (s *Server) List(rw http.ResponseWriter, req *http.Request) {
+	// Set CORS policy to allow third-party websites to use returned resources.
+	rw.Header().Set("Content-Type", "application/json")
+	rw.Header().Set("Access-Control-Allow-Origin", "*")
+	rw.Header().Set("Cache-Control", "no-store") // Prevent caching of result.
+
 	configs := []discovery.StaticConfig{}
 	resp := v0.ListResponse{}
 	hosts, ports, err := s.dnsTracker.List()
@@ -347,7 +352,9 @@ func (s *Server) List(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	org := req.URL.Query().Get("org")
 	format := req.URL.Query().Get("format")
+	sites := []string{}
 
 	// Create a prometheus StaticConfig for each known host.
 	for i := range hosts {
@@ -355,6 +362,11 @@ func (s *Server) List(rw http.ResponseWriter, req *http.Request) {
 		if err != nil {
 			continue
 		}
+		if org != "" && org != h.Org {
+			// Skip hosts that are not part of the given org.
+			continue
+		}
+		sites = append(sites, h.Site)
 		if format == "script-exporter" {
 			// NOTE: do not assign any ports for script exporter.
 			ports[i] = []string{""}
@@ -395,6 +407,9 @@ func (s *Server) List(rw http.ResponseWriter, req *http.Request) {
 		results = configs
 	case "servers":
 		resp.Servers = hosts
+		results = resp
+	case "sites":
+		resp.Sites = sites
 		results = resp
 	default:
 		// NOTE: default format is not valid for prometheus StaticConfig format.

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -592,6 +592,16 @@ func TestServer_List(t *testing.T) {
 			wantLength: 1,
 		},
 		{
+			name:   "success-sites",
+			params: "?format=sites&org=foo",
+			lister: &fakeStatusTracker{
+				nodes: []string{"ndt-lga3356-040e9f4b.mlab.autojoin.measurement-lab.org"},
+				ports: [][]string{{"9990"}},
+			},
+			wantCode:   http.StatusOK,
+			wantLength: 0,
+		},
+		{
 			name:   "success-script-exporter",
 			params: "?format=script-exporter&service=ndt7_client_byos",
 			lister: &fakeStatusTracker{
@@ -634,6 +644,10 @@ func TestServer_List(t *testing.T) {
 				resp := v0.ListResponse{}
 				err = json.Unmarshal(raw, &resp)
 				length = len(resp.Servers)
+			} else if strings.Contains(tt.params, "sites") {
+				resp := v0.ListResponse{}
+				err = json.Unmarshal(raw, &resp)
+				length = len(resp.Sites)
 			} else {
 				resp := v0.ListResponse{}
 				err = json.Unmarshal(raw, &resp)

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -602,6 +602,18 @@ func TestServer_List(t *testing.T) {
 			wantLength: 0,
 		},
 		{
+			name:   "success-one-site-two-nodes",
+			params: "?format=sites&org=mlab",
+			lister: &fakeStatusTracker{
+				nodes: []string{
+					"ndt-lga3356-040e9f4b.mlab.autojoin.measurement-lab.org",
+					"ndt-lga3356-abcdef12.mlab.autojoin.measurement-lab.org"},
+				ports: [][]string{{"9990"}, {"9990"}},
+			},
+			wantCode:   http.StatusOK,
+			wantLength: 1,
+		},
+		{
 			name:   "success-script-exporter",
 			params: "?format=script-exporter&service=ndt7_client_byos",
 			lister: &fakeStatusTracker{


### PR DESCRIPTION
This change allows clients to select known sites and filter them by organization.

This change will be helpful for any Autonode host organization that wishes to create a portal that allows targeting sites individually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/52)
<!-- Reviewable:end -->
