### PR TITLE
Add dispatch.yaml to route autojoin API requests to the autojoin service

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -15,7 +15,7 @@ steps:
   - go test ./... -race
   - go test -v ./...
 
-# Deployment of APIs in sandbox & staging.
+# Deployment of API.
 - name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1
   args:
   - sed -i -e 's/{{PROJECT_ID}}/$PROJECT_ID/g' app.yaml
@@ -24,3 +24,11 @@ steps:
   # After deploying the new service, deploy the openapi spec.
   - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' -e 's/{{DEPLOYMENT}}/$PROJECT_ID/' openapi.yaml
   - gcloud endpoints services deploy openapi.yaml
+
+# Deployment of dispatch for mlab-autojoin.
+# Routes requests to autojoin.measurementlab.net to the autojoin service.
+- name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1
+  env:
+  - PROJECT_IN=mlab-autojoin
+  args:
+  - gcloud --project $PROJECT_ID app deploy dispatch.yaml

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -1,0 +1,7 @@
+# A project may have up to 20 dispatch rules.
+# See also: https://cloud.google.com/appengine/docs/standard/go/reference/dispatch-yaml
+dispatch:
+# Route /autojoin/ requests to the autojoin service.
+- service: autojoin
+  url: "*/autojoin/*"
+# All other requests are routed to their default target.


### PR DESCRIPTION
It is always possible to use URLs constructed by App Engine, such as:
* https://autojoin-dot-mlab-sandbox.appspot.com/autojoin/v0/node/list

However, App Engine also allows custom domains, such as:
* https://autojoin.measurementlab.net/autojoin/v0/node/list

Like locate.measurementlab.net and the [dispatch.yaml config for mlab-ns](https://github.com/m-lab/mlab-ns/blob/main/dispatch.yaml) this PR adds a dispatch.yaml configuration for the production deployment of the autojoin API so autojoin.measurementlab.net can be the canonical API name.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/53)
<!-- Reviewable:end -->
