### PR TITLE
Add autojoin.List usage information & change default list format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,26 @@
 |--------|-----------|------|-------------|
 | main   | [![Coverage Status](https://coveralls.io/repos/github/m-lab/autojoin/badge.svg?branch=main)](https://coveralls.io/github/m-lab/autojoin?branch=main) | [![GoDoc](https://godoc.org/github.com/m-lab/autojoin?status.svg)](https://godoc.org/github.com/m-lab/autojoin) | [![Go Report Card](https://goreportcard.com/badge/github.com/m-lab/autojoin)](https://goreportcard.com/report/github.com/m-lab/autojoin)
 
+# Autojoin API
 
-# autojoin
-Autojoin API
+## List Nodes
+
+The Autojoin API allows listing all known servers for various reasons:
+
+### Request Parameters
+
+Node list operations use the same base url and supports multiple output formats.
+
+Base: `https://autojoin.measurementlab.net/autojoin/v0/node/list`
+
+Formats:
+
+* `format=script-exporter` - output format used by script-exporter.
+* `format=prometheus` - output format used by prometheus to scrape metrics.
+* `format=servers` - simple list known server names.
+* `format=sites` - simple list known site names.
+* `org=<org>` - limit results the given organization.
+
+For example, a client could list all known sites associated with org "foo":
+
+* `https://autojoin.measurementlab.net/autojoin/v0/node/list?format=sites&org=foo`

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -403,7 +403,7 @@ func (s *Server) List(rw http.ResponseWriter, req *http.Request) {
 		fallthrough
 	case "blackbox":
 		fallthrough
-	case "prometheus": // TODO(soltesz): retire this name.
+	case "prometheus":
 		results = configs
 	case "servers":
 		resp.Servers = hosts
@@ -414,8 +414,7 @@ func (s *Server) List(rw http.ResponseWriter, req *http.Request) {
 		}
 		results = resp
 	default:
-		// NOTE: default format is not valid for prometheus StaticConfig format.
-		resp.StaticConfig = configs
+		resp.Servers = hosts
 		results = resp
 	}
 	// Generate as JSON; the list may be empty.

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -559,7 +559,7 @@ func TestServer_List(t *testing.T) {
 				ports: [][]string{{"9990", "9991"}},
 			},
 			wantCode:   http.StatusOK,
-			wantLength: 2,
+			wantLength: 1,
 		},
 		{
 			name:   "success-prometheus",
@@ -663,8 +663,7 @@ func TestServer_List(t *testing.T) {
 			} else {
 				resp := v0.ListResponse{}
 				err = json.Unmarshal(raw, &resp)
-				configs = resp.StaticConfig
-				length = len(configs)
+				length = len(resp.Servers)
 			}
 			testingx.Must(t, err, "failed to unmarshal response")
 


### PR DESCRIPTION
This change modifies the default autojoin.List format to `servers` and adds usage information for the various supported formats.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/54)
<!-- Reviewable:end -->
