### PR TITLE
Handle alternate errors for GetKeyString

### DIFF
--- a/internal/adminx/apikeys.go
+++ b/internal/adminx/apikeys.go
@@ -57,5 +57,8 @@ func (a *APIKeys) CreateKey(ctx context.Context, org string) (string, error) {
 		}
 		return key.KeyString, nil
 	}
+	if err != nil {
+		return "", err
+	}
 	return get.KeyString, nil
 }

--- a/internal/adminx/apikeys_test.go
+++ b/internal/adminx/apikeys_test.go
@@ -65,6 +65,16 @@ func TestAPIKeys_CreateKey(t *testing.T) {
 			namer:   NewNamer("mlab-foo"),
 			wantErr: true,
 		},
+		{
+			name:          "error-other-error",
+			org:           "foo",
+			locateProject: "mlab-foo",
+			fakeKeys: &fakeKeys{
+				getKeyErr: fmt.Errorf("fake error"),
+			},
+			namer:   NewNamer("mlab-foo"),
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This change adds an additional error handling case that was previously missing and could result in the `orgadm` command crashing when permission or other transient errors resulted in an error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/55)
<!-- Reviewable:end -->
