### PR TITLE
Fix: orgadm locate project & register missing credential abort

### DIFF
--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -149,14 +149,14 @@ func register() {
 	err = os.WriteFile(path.Join(*outputPath, annotationFilename), annotationJSON, 0644)
 	rtx.Must(err, "Failed to write annotation file")
 
-	// Service account credentials.
-	if r.Registration.Credentials != nil {
-		// TODO(soltesz): abort on nil after deployment.
-		key, err := base64.StdEncoding.DecodeString(r.Registration.Credentials.ServiceAccountKey)
-		rtx.Must(err, "Failed to decode service account key")
-		err = os.WriteFile(path.Join(*outputPath, serviceAccountFilename), key, 0644)
-		rtx.Must(err, "Failed to write annotation file")
+	if r.Registration.Credentials == nil {
+		log.Fatalf("Registration credentials are nil:\n%s", body)
 	}
+	// Service account credentials.
+	key, err := base64.StdEncoding.DecodeString(r.Registration.Credentials.ServiceAccountKey)
+	rtx.Must(err, "Failed to decode service account key")
+	err = os.WriteFile(path.Join(*outputPath, serviceAccountFilename), key, 0644)
+	rtx.Must(err, "Failed to write annotation file")
 
 	log.Printf("Registration successful with hostname: %s", r.Registration.Hostname)
 	registerSuccess.Store(true)


### PR DESCRIPTION
This change fixes one bug and adds a failure condition during register.

* orgadm needs the Locate API project to authorize a new API key - previously the wrong project was provided to `adminx.NewAPIKeys()`
* register now aborts if the Autojoin API Register returns nil credentials. This was allowed only temporarily while the feature was deployed. Jostler depends on these credentials.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/56)
<!-- Reviewable:end -->
