### PR TITLE
Convert three register flags to type flagx.StringFile

### DIFF
--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -68,7 +68,7 @@ func Ready(rw http.ResponseWriter, req *http.Request) {
 func main() {
 	flag.Parse()
 
-	if *endpoint == "" || *apiKey == "" || *service == "" || *org == "" || *iata == "" {
+	if *endpoint == "" || *apiKey == "" || *service == "" || *org == "" || iata.Value == "" {
 		panic("-key, -service, -organization, and -iata are required.")
 	}
 	if *siteProb <= 0.0 || *siteProb > 1.0 {
@@ -107,9 +107,9 @@ func register() {
 	q.Add("api_key", *apiKey)
 	q.Add("service", *service)
 	q.Add("organization", *org)
-	q.Add("iata", *iata)
-	q.Add("ipv4", *ipv4)
-	q.Add("ipv6", *ipv6)
+	q.Add("iata", iata.Value)
+	q.Add("ipv4", ipv4.Value)
+	q.Add("ipv6", ipv6.Value)
 	q.Add("probability", fmt.Sprintf("%f", *siteProb))
 	for _, port := range ports {
 		q.Add("ports", port)

--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -36,9 +36,9 @@ var (
 	apiKey      = flag.String("key", "", "API key for the autojoin service")
 	service     = flag.String("service", "ndt", "Service name to register with the autojoin service")
 	org         = flag.String("organization", "", "Organization to register with the autojoin service")
-	iata        = flag.String("iata", "", "IATA code to register with the autojoin service")
-	ipv4        = flag.String("ipv4", "", "IPv4 address to register with the autojoin service")
-	ipv6        = flag.String("ipv6", "", "IPv6 address to register with the autojoin service")
+	iata        = flagx.StringFile{}
+	ipv4        = flagx.StringFile{}
+	ipv6        = flagx.StringFile{}
 	interval    = flag.Duration("interval.expected", 1*time.Hour, "Expected registration interval")
 	intervalMin = flag.Duration("interval.min", 55*time.Minute, "Minimum registration interval")
 	intervalMax = flag.Duration("interval.max", 65*time.Minute, "Maximum registration interval")
@@ -52,6 +52,9 @@ var (
 
 func init() {
 	flag.Var(&ports, "ports", "Ports to monitor for this service")
+	flag.Var(&iata, "iata", "IATA code to register with the autojoin service")
+	flag.Var(&ipv4, "ipv4", "IPv4 address to register with the autojoin service")
+	flag.Var(&ipv6, "ipv6", "IPv6 address to register with the autojoin service")
 }
 
 func Ready(rw http.ResponseWriter, req *http.Request) {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/googleapis/gax-go v1.0.3
 	github.com/googleapis/gax-go/v2 v2.13.0
 	github.com/m-lab/gcp-service-discovery v1.5.1
-	github.com/m-lab/go v0.1.71
+	github.com/m-lab/go v0.1.75
 	github.com/m-lab/locate v0.14.49
 	github.com/m-lab/uuid-annotator v0.5.6
 	github.com/oschwald/geoip2-golang v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -284,6 +284,8 @@ github.com/m-lab/gcp-service-discovery v1.5.1/go.mod h1:ibZ81sW6Z8M/9pfIOc+iiJCU
 github.com/m-lab/go v0.1.45/go.mod h1:05mdACIqCaSuf57iYC6mDhomYdyzSgkWeR5CgZIXU6Y=
 github.com/m-lab/go v0.1.71 h1:VTfoAzsWRstsTBDvt4Ss9lJ6J6QcWvOmI2gr3OboJ1o=
 github.com/m-lab/go v0.1.71/go.mod h1:BirARfHWjjXHaCGNyWCm/CKW1OarjuEj8Yn6Z2rc0M4=
+github.com/m-lab/go v0.1.75 h1:t4kvig26aUBznA0b3e997Jn0BjELAOKpO1xILWp2VJs=
+github.com/m-lab/go v0.1.75/go.mod h1:BirARfHWjjXHaCGNyWCm/CKW1OarjuEj8Yn6Z2rc0M4=
 github.com/m-lab/locate v0.14.49 h1:M7SNJAU/fbsdWHqCOAHpWajD7mgnjN8shm8usAZMDqU=
 github.com/m-lab/locate v0.14.49/go.mod h1:Wahmsdym1dE3/+6Z1yUriDhCnV5c+ug8jWV1GNAIYMg=
 github.com/m-lab/tcp-info v1.5.3 h1:4IspTPcNc8D8LNRvuFnID8gDiz+hxPAtYvpKZaiGGe8=


### PR DESCRIPTION
We are working on having M-Lab managed VMs leverage the Autojoin API in order to get a dynamic DNS name. The value of several of the flags to the `register` command are already present on the local filesystem of our VMs in the /var/local/metadata directory. Namely, external IPv4 and IPv6 addresses and the IATA code for the site. This PR coverts the `-iata`, `-ipv4` and `-ipv6` flags to be of type flagx.StringFile, which allow us to specify a path to a file instead of a static string value for these flags.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/57)
<!-- Reviewable:end -->
