### PR TITLE
Wait for last operation if not completed

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,7 +28,15 @@ steps:
 # Deployment of dispatch for mlab-autojoin.
 # Routes requests to autojoin.measurementlab.net to the autojoin service.
 - name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1
+  entrypoint: bash
   env:
   - PROJECT_IN=mlab-autojoin
   args:
-  - gcloud --project $PROJECT_ID app deploy dispatch.yaml
+  - -c
+  - |-
+    # Wait for the first non-completed operation.
+    gcloud --project $PROJECT_ID app operations wait \
+      $$( gcloud  --project mlab-autojoin app operations list \
+           | grep -vE 'STATUS|COMPLETED' | awk '{print $1}' | head -1 ) 2> /dev/null || :
+    # Deploy dispatch after operations are complete.
+    gcloud --project $PROJECT_ID app deploy dispatch.yaml


### PR DESCRIPTION
The Autojoin API deployment includes three distinct steps in production:

1. deploy the autojoin App Engine service
2. deploy the openapi endpoints API
3. deploy the dispatch.yml to direct requests to this service for custom domain names

While step 2 will return successfully, the operation it creates is not yet "COMPLETE" by the time step 3 begins, which generates a build error like the one below.

This change adds an explicit `operation wait` on that operation before continuing to step 3.

Build error:

```
Step #2: ERROR: (gcloud.app.deploy) Apps instance [mlab-autojoin] is the
subject of a conflict: Cannot operate on apps/mlab-autojoin because an
operation is already in progress for apps/mlab-autojoin by e309c37c-1c30-4074-9c06-4805a0935b05.
```
