### PR TITLE
Allow passing Type and Uplink in registration requests

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -184,9 +184,8 @@ func (s *Server) Register(rw http.ResponseWriter, req *http.Request) {
 	}
 	param.Type = req.URL.Query().Get("type")
 	if !isValidType(param.Type) {
-		fmt.Printf("bad machine type")
 		resp.Error = &v2.Error{
-			Type:   "?machine-type=<machine-type>",
+			Type:   "?type=<type>",
 			Title:  "invalid machine type from request",
 			Status: http.StatusBadRequest,
 		}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -341,7 +341,7 @@ func TestServer_Register(t *testing.T) {
 	}{
 		{
 			name:    "success",
-			params:  "?service=foo&organization=bar&iata=lga&ipv4=192.168.0.1&probability=1.0&ports=9990",
+			params:  "?service=foo&organization=bar&iata=lga&ipv4=192.168.0.1&probability=1.0&ports=9990&type=physical&uplink=10g",
 			Iata:    iataFinder,
 			Maxmind: maxmind,
 			ASN:     fakeASN,
@@ -355,7 +355,7 @@ func TestServer_Register(t *testing.T) {
 		},
 		{
 			name:    "success-probability-invalid-ports-invalid",
-			params:  "?service=foo&organization=bar&iata=lga&ipv4=192.168.0.1&probability=invalid&ports=invalid",
+			params:  "?service=foo&organization=bar&iata=lga&ipv4=192.168.0.1&probability=invalid&ports=invalid&type=virtual&uplink=10g",
 			Iata:    iataFinder,
 			Maxmind: maxmind,
 			ASN:     fakeASN,
@@ -383,6 +383,16 @@ func TestServer_Register(t *testing.T) {
 			wantCode: http.StatusBadRequest,
 		},
 		{
+			name:     "error-bad-type",
+			params:   "?service=foo&organization=bar&iata=lga&ipv4=192.168.0.1&probability=0.5&ports=9990&type=dell&uplink=50g",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "error-bad-uplink",
+			params:   "?service=foo&organization=bar&iata=lga&ipv4=192.168.0.1&probability=0.5&ports=9990&type=virtual&uplink=10",
+			wantCode: http.StatusBadRequest,
+		},
+		{
 			name:     "error-bad-ip",
 			params:   "?service=foo&organization=bar&ipv4=-BAD-IP-",
 			wantCode: http.StatusBadRequest,
@@ -395,19 +405,19 @@ func TestServer_Register(t *testing.T) {
 		{
 			name:     "error-bad-iata-find",
 			Iata:     &fakeIataFinder{findErr: errors.New("find err")},
-			params:   "?service=foo&organization=bar&ipv4=192.168.0.1&iata=123",
+			params:   "?service=foo&organization=bar&ipv4=192.168.0.1&iata=123&type=physical&uplink=20g",
 			wantCode: http.StatusInternalServerError,
 		},
 		{
 			name:     "error-bad-maxmind-city",
 			Iata:     &fakeIataFinder{findRow: iata.Row{}},
 			Maxmind:  &fakeMaxmind{err: errors.New("fake maxmind error")},
-			params:   "?service=foo&organization=bar&ipv4=192.168.0.1&iata=abc",
+			params:   "?service=foo&organization=bar&ipv4=192.168.0.1&iata=abc&type=virtual&uplink=1000g",
 			wantCode: http.StatusInternalServerError,
 		},
 		{
 			name:    "error-loading-key",
-			params:  "?service=foo&organization=bar&iata=lga&ipv4=192.168.0.1",
+			params:  "?service=foo&organization=bar&iata=lga&ipv4=192.168.0.1&type=physical&uplink=10g",
 			Iata:    iataFinder,
 			Maxmind: maxmind,
 			ASN:     fakeASN,
@@ -419,7 +429,7 @@ func TestServer_Register(t *testing.T) {
 		},
 		{
 			name:    "error-registration",
-			params:  "?service=foo&organization=bar&iata=lga&ipv4=192.168.0.1",
+			params:  "?service=foo&organization=bar&iata=lga&ipv4=192.168.0.1&type=virtual&uplink=1g",
 			Iata:    iataFinder,
 			Maxmind: maxmind,
 			ASN:     fakeASN,
@@ -431,7 +441,7 @@ func TestServer_Register(t *testing.T) {
 		},
 		{
 			name:    "error-tracker-update-error",
-			params:  "?service=foo&organization=bar&iata=lga&ipv4=192.168.0.1",
+			params:  "?service=foo&organization=bar&iata=lga&ipv4=192.168.0.1&type=physical&uplink=20g",
 			Iata:    iataFinder,
 			Maxmind: maxmind,
 			ASN:     fakeASN,

--- a/internal/register/register.go
+++ b/internal/register/register.go
@@ -28,6 +28,8 @@ type Params struct {
 	Metro       iata.Row
 	Network     *annotator.Network
 	Probability float64
+	Type        string
+	Uplink      string
 }
 
 // CreateRegisterResponse generates a RegisterResponse from the given
@@ -98,8 +100,8 @@ func CreateRegisterResponse(p *Params) v0.RegisterResponse {
 				Project:       p.Project,
 				Probability:   p.Probability,
 				Site:          site,
-				Type:          "unknown", // should be overridden by node.
-				Uplink:        "unknown", // should be overridden by node.
+				Type:          p.Type,
+				Uplink:        p.Uplink,
 			},
 		},
 	}

--- a/internal/register/register_test.go
+++ b/internal/register/register_test.go
@@ -63,6 +63,8 @@ func TestCreateRegisterResponse(t *testing.T) {
 					ASNumber: 12345,
 				},
 				Probability: 1.0,
+				Type:        "physical",
+				Uplink:      "10g",
 			},
 			want: v0.RegisterResponse{
 				Registration: &v0.Registration{
@@ -101,8 +103,8 @@ func TestCreateRegisterResponse(t *testing.T) {
 						Project:     "mlab-sandbox",
 						Probability: 1,
 						Site:        "lga12345",
-						Type:        "unknown",
-						Uplink:      "unknown",
+						Type:        "physical",
+						Uplink:      "10g",
 					},
 				},
 			},


### PR DESCRIPTION
Currently, both `Type` and `Uplink` in v2.Registration are statically set to "unknown". This change allows (requires) that valid-looking values for those fields be passed in registration commands.

We will need to be sure that RNP has updated their configurations before we release this, and also that our own test instances. Alternatively, I could update these changes to make these fields optional. I chose to make them required because it puts autojoined machines at parity with every other machine on the platform, where those fields are always present.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/60)
<!-- Reviewable:end -->
