### PR TITLE
Sets GC_TTL=14d + adds new metrics package

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -20,6 +20,7 @@ network:
   subnetwork_name: gae
   forwarded_ports:
     - 9090/tcp
+  instance_tag: autojoin
 
 liveness_check:
   path: "/v0/live"
@@ -34,3 +35,4 @@ env_variables:
   MAXMIND_URL: gs://downloader-{{PROJECT_ID}}/Maxmind/current/GeoLite2-City.tar.gz
   ROUTEVIEW_V4_URL: gs://downloader-{{PROJECT_ID}}/RouteViewIPv4/current/routeview.pfx2as.gz
   REDIS_ADDRESS: {{REDIS_ADDRESS}}
+  GC_TTL: 336h # 14d

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,29 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// DNSExpiration is a metric for exposing how long until a machine's DNS
+	// record will be removed from Cloud DNS.
+	DNSExpiration = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "autojoin_dns_expiration",
+			Help: "The amount of time before a DNS record will be removed",
+		},
+		[]string{
+			"hostname",
+		},
+	)
+
+	// RequestHandlerDuration is a histogram that tracks the latency of each request handler.
+	RequestHandlerDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "autojoin_request_handler_duration",
+			Help: "A histogram of latencies for each request handler.",
+		},
+		[]string{"path", "code"},
+	)
+)

--- a/internal/tracker/gc.go
+++ b/internal/tracker/gc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/m-lab/autojoin/internal/dnsname"
 	"github.com/m-lab/autojoin/internal/dnsx"
 	"github.com/m-lab/autojoin/internal/dnsx/dnsiface"
+	"github.com/m-lab/autojoin/internal/metrics"
 	"github.com/m-lab/go/host"
 	"github.com/m-lab/locate/memorystore"
 )
@@ -122,6 +123,7 @@ func (gc *GarbageCollector) checkAndRemoveExpired() ([]string, [][]string, error
 	// Iterate over values and check if they are expired.
 	for k, v := range values {
 		lastUpdate := time.Unix(v.DNS.LastUpdate, 0)
+		metrics.DNSExpiration.WithLabelValues(k).Set(float64(lastUpdate.Add(gc.ttl).Unix()))
 		if time.Since(lastUpdate) > gc.ttl {
 			log.Printf("%s expired on %s, deleting from Cloud DNS and memorystore", k, lastUpdate.Add(gc.ttl))
 

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/m-lab/autojoin/internal/adminx/iamiface"
 	"github.com/m-lab/autojoin/internal/dnsx/dnsiface"
 	"github.com/m-lab/autojoin/internal/maxmind"
+	"github.com/m-lab/autojoin/internal/metrics"
 	"github.com/m-lab/autojoin/internal/tracker"
 	"github.com/m-lab/go/content"
 	"github.com/m-lab/go/flagx"
@@ -25,7 +26,6 @@ import (
 	"github.com/m-lab/locate/memorystore"
 	"github.com/m-lab/uuid-annotator/asnannotator"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/api/dns/v1"
 	"google.golang.org/api/iam/v1"
@@ -40,15 +40,6 @@ var (
 	routeviewSrc = flagx.URL{}
 	gcTTL        time.Duration
 	gcInterval   time.Duration
-
-	// RequestHandlerDuration is a histogram that tracks the latency of each request handler.
-	RequestHandlerDuration = promauto.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name: "autojoin_request_handler_duration",
-			Help: "A histogram of latencies for each request handler.",
-		},
-		[]string{"path", "code"},
-	)
 )
 
 func init() {
@@ -146,21 +137,21 @@ func main() {
 	mux := http.NewServeMux()
 	// USER APIs
 	mux.HandleFunc("/autojoin/v0/lookup", promhttp.InstrumentHandlerDuration(
-		RequestHandlerDuration.MustCurryWith(prometheus.Labels{"path": "/autojoin/v0/lookup"}),
+		metrics.RequestHandlerDuration.MustCurryWith(prometheus.Labels{"path": "/autojoin/v0/lookup"}),
 		http.HandlerFunc(s.Lookup)))
 
 	// AUTOJOIN APIs
 	// Nodes register on start up.
 	mux.HandleFunc("/autojoin/v0/node/register", promhttp.InstrumentHandlerDuration(
-		RequestHandlerDuration.MustCurryWith(prometheus.Labels{"path": "/autojoin/v0/node/register"}),
+		metrics.RequestHandlerDuration.MustCurryWith(prometheus.Labels{"path": "/autojoin/v0/node/register"}),
 		http.HandlerFunc(s.Register)))
 
 	mux.HandleFunc("/autojoin/v0/node/delete", promhttp.InstrumentHandlerDuration(
-		RequestHandlerDuration.MustCurryWith(prometheus.Labels{"path": "/autojoin/v0/node/delete"}),
+		metrics.RequestHandlerDuration.MustCurryWith(prometheus.Labels{"path": "/autojoin/v0/node/delete"}),
 		http.HandlerFunc(s.Delete)))
 
 	mux.HandleFunc("/autojoin/v0/node/list", promhttp.InstrumentHandlerDuration(
-		RequestHandlerDuration.MustCurryWith(prometheus.Labels{"path": "/autojoin/v0/node/list"}),
+		metrics.RequestHandlerDuration.MustCurryWith(prometheus.Labels{"path": "/autojoin/v0/node/list"}),
 		http.HandlerFunc(s.List)))
 
 	// Liveness and Readiness checks to support deployments.


### PR DESCRIPTION
This PR sets the `-gc-ttl` flag of autojoin to 14d, up from the default of 3h. The notion is that there is no urgency in removing DNS records for autojoined machines that have not contacted the Autojoin API for some time. Additionally, setting it to 14d gives M-Lab breathing room for making use of the Autojoin system for its own platform VMs without having to worry that some bug in the autojoin client or the API might remove all DNS entries after just a few hours, taking down the virtual platform.

Additionally, this PR adds creates a new "metrics" package, and introduces a new metric named `autojoin_dns_expiration`. This new metric returns the Unix timestamp for when the DNS record for a given machine will be removed. Since the Autojoin client is supposed to report to the Autojoin API every hour, when the value for this metric is less than 14d, this could indicate a problem. A new alert will be created for when more than a certain percentage  of autojoined VMs have an expiration that is less than expected.

Additionally, this PR add network.instance_tag="autojoin" to app.yaml. This sets a network tag on all VMs created by the AppEngine instance. This tag will be used in a firewall rule which allow access to port 9090 (prometheus) on those nodes to allow monitoring. Monitoring of the actual Autojoin API was previously broken since late August.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/62)
<!-- Reviewable:end -->
