### PR TITLE
Update autojoin API to verify keys from Datastore

### DIFF
--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -36,7 +36,6 @@ var (
 	endpoint    = flag.String("endpoint", registerEndpoint, "Endpoint of the autojoin service")
 	apiKey      = flag.String("key", "", "API key for the autojoin service")
 	service     = flag.String("service", "ndt", "Service name to register with the autojoin service")
-	org         = flag.String("organization", "", "Organization to register with the autojoin service")
 	iata        = flagx.StringFile{}
 	ipv4        = flagx.StringFile{}
 	ipv6        = flagx.StringFile{}
@@ -85,8 +84,9 @@ func main() {
 		}
 	}
 
-	if *endpoint == "" || *apiKey == "" || *service == "" || *org == "" || iata.Value == "" {
-		panic("-key, -service, -organization, and -iata are required.")
+	if *endpoint == "" || *apiKey == "" || *service == "" || iata.Value == "" ||
+		*machineType == "" || *uplink == "" {
+		panic("-key, -service, -iata, -type and -uplink are required.")
 	}
 	if probability <= 0.0 || probability > 1.0 {
 		panic("-probability must be in the range (0, 1]")
@@ -125,7 +125,6 @@ func register() {
 	q := registerURL.Query()
 	q.Add("api_key", *apiKey)
 	q.Add("service", *service)
-	q.Add("organization", *org)
 	q.Add("iata", iata.Value)
 	q.Add("ipv4", ipv4.Value)
 	q.Add("ipv6", ipv6.Value)

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -157,18 +157,20 @@ func (s *Server) Register(rw http.ResponseWriter, req *http.Request) {
 		writeResponse(rw, resp)
 		return
 	}
-	// TODO(soltesz): discover this from a given API key.
-	param.Org = req.URL.Query().Get("organization")
-	if !isValidName(param.Org) {
+
+	// Get the organization from the context.
+	org, ok := req.Context().Value(orgContextKey).(string)
+	if !ok {
 		resp.Error = &v2.Error{
-			Type:   "?organization=<organization>",
-			Title:  "could not determine organization from request",
-			Status: http.StatusBadRequest,
+			Type:   "auth.context",
+			Title:  "missing organization in context",
+			Status: http.StatusInternalServerError,
 		}
 		rw.WriteHeader(resp.Error.Status)
 		writeResponse(rw, resp)
 		return
 	}
+	param.Org = org
 	param.IPv6 = checkIP(req.URL.Query().Get("ipv6")) // optional.
 	param.IPv4 = checkIP(getClientIP(req))
 	ip := net.ParseIP(param.IPv4)

--- a/handler/validator.go
+++ b/handler/validator.go
@@ -1,0 +1,59 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	v0 "github.com/m-lab/autojoin/api/v0"
+	v2 "github.com/m-lab/locate/api/v2"
+)
+
+type contextKey string
+
+const orgContextKey contextKey = "organization"
+
+// APIKeyValidator is an interface for validating API keys and retrieving
+// associated organization info.
+type APIKeyValidator interface {
+	// ValidateKey validates the provided API key and returns the associated
+	// organization name if valid. Returns an error if the key is invalid.
+	ValidateKey(ctx context.Context, key string) (string, error)
+}
+
+// WithAPIKeyValidation creates middleware that validates API keys and adds
+// org info to context.
+func WithAPIKeyValidation(validator APIKeyValidator, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		apiKey := r.URL.Query().Get("key")
+		if apiKey == "" {
+			resp := v0.RegisterResponse{
+				Error: &v2.Error{
+					Type:   "?key=<key>",
+					Title:  "API key is required",
+					Status: http.StatusUnauthorized,
+				},
+			}
+			w.WriteHeader(resp.Error.Status)
+			writeResponse(w, resp)
+			return
+		}
+
+		org, err := validator.ValidateKey(r.Context(), apiKey)
+		if err != nil {
+			resp := v0.RegisterResponse{
+				Error: &v2.Error{
+					Type:   "auth.invalid_key",
+					Title:  "Invalid API key",
+					Status: http.StatusUnauthorized,
+				},
+			}
+			w.WriteHeader(resp.Error.Status)
+			writeResponse(w, resp)
+			return
+		}
+
+		// Add org to context
+		ctx := context.WithValue(r.Context(), orgContextKey, org)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	}
+}

--- a/handler/validator.go
+++ b/handler/validator.go
@@ -24,11 +24,11 @@ type APIKeyValidator interface {
 // org info to context.
 func WithAPIKeyValidation(validator APIKeyValidator, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		apiKey := r.URL.Query().Get("key")
+		apiKey := r.URL.Query().Get("api_key")
 		if apiKey == "" {
 			resp := v0.RegisterResponse{
 				Error: &v2.Error{
-					Type:   "?key=<key>",
+					Type:   "?api_key=<key>",
 					Title:  "API key is required",
 					Status: http.StatusUnauthorized,
 				},

--- a/handler/validator_test.go
+++ b/handler/validator_test.go
@@ -60,7 +60,7 @@ func TestWithAPIKeyValidation(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			}
 
-			req := httptest.NewRequest("GET", "/?key="+tt.apiKey, nil)
+			req := httptest.NewRequest("GET", "/?api_key="+tt.apiKey, nil)
 			w := httptest.NewRecorder()
 
 			WithAPIKeyValidation(tt.validator, handler)(w, req)

--- a/handler/validator_test.go
+++ b/handler/validator_test.go
@@ -1,0 +1,76 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type fakeKeyValidator struct {
+	org string
+	err error
+}
+
+func (f *fakeKeyValidator) ValidateKey(ctx context.Context, key string) (string, error) {
+	return f.org, f.err
+}
+
+func TestWithAPIKeyValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		validator APIKeyValidator
+		apiKey    string
+		wantCode  int
+		wantOrg   string
+	}{
+		{
+			name: "success",
+			validator: &fakeKeyValidator{
+				org: "test-org",
+				err: nil,
+			},
+			apiKey:   "valid-key",
+			wantCode: http.StatusOK,
+			wantOrg:  "test-org",
+		},
+		{
+			name:      "error-missing-key",
+			validator: &fakeKeyValidator{},
+			apiKey:    "",
+			wantCode:  http.StatusUnauthorized,
+		},
+		{
+			name: "error-invalid-key",
+			validator: &fakeKeyValidator{
+				err: errors.New("invalid key"),
+			},
+			apiKey:   "invalid-key",
+			wantCode: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotOrg string
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				org, _ := r.Context().Value(orgContextKey).(string)
+				gotOrg = org
+				w.WriteHeader(http.StatusOK)
+			}
+
+			req := httptest.NewRequest("GET", "/?key="+tt.apiKey, nil)
+			w := httptest.NewRecorder()
+
+			WithAPIKeyValidation(tt.validator, handler)(w, req)
+
+			if w.Code != tt.wantCode {
+				t.Errorf("WithAPIKeyValidation() status = %v, want %v", w.Code, tt.wantCode)
+			}
+			if tt.wantCode == http.StatusOK && gotOrg != tt.wantOrg {
+				t.Errorf("WithAPIKeyValidation() org = %v, want %v", gotOrg, tt.wantOrg)
+			}
+		})
+	}
+}

--- a/internal/adminx/apikeys_test.go
+++ b/internal/adminx/apikeys_test.go
@@ -4,30 +4,9 @@ import (
 	"context"
 	"errors"
 	"testing"
-
-	"cloud.google.com/go/datastore"
 )
 
 var errTest = errors.New("test error")
-
-type fakeDatastore struct {
-	putErr error
-	getErr error
-	keys   []*datastore.Key
-	getAll []string
-}
-
-func (f *fakeDatastore) Put(ctx context.Context, key *datastore.Key, src interface{}) (*datastore.Key, error) {
-	return key, f.putErr
-}
-
-func (f *fakeDatastore) Get(ctx context.Context, key *datastore.Key, dst interface{}) error {
-	return f.getErr
-}
-
-func (f *fakeDatastore) GetAll(ctx context.Context, q *datastore.Query, dst interface{}) ([]*datastore.Key, error) {
-	return f.keys, f.getErr
-}
 
 func TestAPIKeys_CreateKey(t *testing.T) {
 	tests := []struct {

--- a/internal/adminx/datastore.go
+++ b/internal/adminx/datastore.go
@@ -35,6 +35,7 @@ type Organization struct {
 // APIKey represents a Datastore entity for storing API key metadata.
 type APIKey struct {
 	CreatedAt time.Time `datastore:"created_at"`
+	Key       string    `datastore:"key"`
 }
 
 // DatastoreOrgManager maintains state for managing organizations and API keys in Datastore
@@ -85,6 +86,7 @@ func (d *DatastoreOrgManager) CreateAPIKey(ctx context.Context, org string) (str
 
 	apiKey := &APIKey{
 		CreatedAt: time.Now().UTC(),
+		Key:       keyString,
 	}
 
 	_, err = d.client.Put(ctx, key, apiKey)
@@ -119,7 +121,7 @@ func (d *DatastoreOrgManager) GetAPIKeys(ctx context.Context, org string) ([]str
 func (d *DatastoreOrgManager) ValidateKey(ctx context.Context, key string) (string, error) {
 	q := datastore.NewQuery(APIKeyKind).
 		Namespace(d.namespace).
-		FilterField("__key__", "=", datastore.NameKey(APIKeyKind, key, nil))
+		FilterField("key", "=", key).Limit(1)
 
 	var keys []*datastore.Key
 	var entities []APIKey

--- a/internal/adminx/datastore.go
+++ b/internal/adminx/datastore.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"time"
 
 	"cloud.google.com/go/datastore"
@@ -124,6 +125,7 @@ func (d *DatastoreOrgManager) ValidateKey(ctx context.Context, key string) (stri
 	// Try to get the entity
 	var keyEntity APIKey
 	err := d.client.Get(ctx, apiKey, &keyEntity)
+	fmt.Printf("keyEntity: %v, err: %v\n", keyEntity, err)
 	if err == datastore.ErrNoSuchEntity {
 		return "", ErrInvalidKey
 	}
@@ -133,6 +135,7 @@ func (d *DatastoreOrgManager) ValidateKey(ctx context.Context, key string) (stri
 
 	// Get the parent (organization) key
 	orgKey := apiKey.Parent
+	fmt.Printf("orgKey: %v\n", orgKey)
 	if orgKey == nil {
 		return "", errors.New("API key has no parent organization")
 	}

--- a/internal/adminx/datastore.go
+++ b/internal/adminx/datastore.go
@@ -4,12 +4,20 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"time"
 
 	"cloud.google.com/go/datastore"
 )
 
 const autojoinNamespace = "autojoin"
+const OrgKind = "Organization"
+const APIKeyKind = "APIKey"
+
+var (
+	// ErrInvalidKey is returned when the API key is not found in Datastore
+	ErrInvalidKey = errors.New("invalid API key")
+)
 
 type DatastoreClient interface {
 	Put(ctx context.Context, key *datastore.Key, src interface{}) (*datastore.Key, error)
@@ -47,7 +55,7 @@ func NewDatastoreManager(client DatastoreClient, project string) *DatastoreOrgMa
 
 // Add CreateOrganization method
 func (d *DatastoreOrgManager) CreateOrganization(ctx context.Context, name, email string) error {
-	key := datastore.NameKey("Organization", name, nil)
+	key := datastore.NameKey(OrgKind, name, nil)
 	key.Namespace = d.namespace
 
 	org := &Organization{
@@ -62,7 +70,7 @@ func (d *DatastoreOrgManager) CreateOrganization(ctx context.Context, name, emai
 
 // CreateAPIKey creates a new API key as a child entity of the organization
 func (d *DatastoreOrgManager) CreateAPIKey(ctx context.Context, org string) (string, error) {
-	parentKey := datastore.NameKey("Organization", org, nil)
+	parentKey := datastore.NameKey(OrgKind, org, nil)
 	parentKey.Namespace = d.namespace
 
 	// Generate random API key
@@ -72,7 +80,7 @@ func (d *DatastoreOrgManager) CreateAPIKey(ctx context.Context, org string) (str
 	}
 
 	// Use the generated string as the key name
-	key := datastore.NameKey("APIKey", keyString, parentKey)
+	key := datastore.NameKey(APIKeyKind, keyString, parentKey)
 	key.Namespace = d.namespace
 
 	apiKey := &APIKey{
@@ -89,10 +97,10 @@ func (d *DatastoreOrgManager) CreateAPIKey(ctx context.Context, org string) (str
 
 // GetAPIKeys retrieves all API keys for an organization
 func (d *DatastoreOrgManager) GetAPIKeys(ctx context.Context, org string) ([]string, error) {
-	parentKey := datastore.NameKey("Organization", org, nil)
+	parentKey := datastore.NameKey(OrgKind, org, nil)
 	parentKey.Namespace = d.namespace
 
-	q := datastore.NewQuery("APIKey").Ancestor(parentKey).KeysOnly()
+	q := datastore.NewQuery(APIKeyKind).Ancestor(parentKey).KeysOnly()
 
 	keys, err := d.client.GetAll(ctx, q, nil)
 	if err != nil {
@@ -105,6 +113,31 @@ func (d *DatastoreOrgManager) GetAPIKeys(ctx context.Context, org string) ([]str
 	}
 
 	return apiKeys, nil
+}
+
+// ValidateKey checks if the API key exists and returns the associated organization name.
+func (d *DatastoreOrgManager) ValidateKey(ctx context.Context, key string) (string, error) {
+	// Create the key to look up.
+	apiKey := datastore.NameKey(APIKeyKind, key, nil)
+	apiKey.Namespace = d.namespace
+
+	// Try to get the entity
+	var keyEntity APIKey
+	err := d.client.Get(ctx, apiKey, &keyEntity)
+	if err == datastore.ErrNoSuchEntity {
+		return "", ErrInvalidKey
+	}
+	if err != nil {
+		return "", err
+	}
+
+	// Get the parent (organization) key
+	orgKey := apiKey.Parent
+	if orgKey == nil {
+		return "", errors.New("API key has no parent organization")
+	}
+
+	return orgKey.Name, nil
 }
 
 // GenerateAPIKey generates a random string to be used as API key.

--- a/internal/adminx/datastore_test.go
+++ b/internal/adminx/datastore_test.go
@@ -40,7 +40,27 @@ func (f *fakeDatastore) Get(ctx context.Context, key *datastore.Key, dst interfa
 }
 
 func (f *fakeDatastore) GetAll(ctx context.Context, q *datastore.Query, dst interface{}) ([]*datastore.Key, error) {
-	return nil, f.getErr
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+
+	// If we have test data, return it
+	if f.keys != nil {
+		// Get the destination slice
+		entities := dst.(*[]APIKey)
+		keys := []*datastore.Key{}
+
+		// Add each test entity to the results
+		for keyName, entry := range f.keys {
+			*entities = append(*entities, *entry.entity)
+			key := datastore.NameKey(APIKeyKind, keyName, entry.parent)
+			keys = append(keys, key)
+		}
+		return keys, nil
+	}
+
+	// Empty results if no test data
+	return []*datastore.Key{}, nil
 }
 
 func TestDatastoreOrgManager_ValidateKey(t *testing.T) {

--- a/internal/adminx/datastore_test.go
+++ b/internal/adminx/datastore_test.go
@@ -1,0 +1,108 @@
+package adminx
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/datastore"
+)
+
+type fakeDatastore struct {
+	// Map of key name to (entity, parent key) pair
+	keys map[string]struct {
+		entity *APIKey
+		parent *datastore.Key
+	}
+	putErr error
+	getErr error
+}
+
+func (f *fakeDatastore) Put(ctx context.Context, key *datastore.Key, src interface{}) (*datastore.Key, error) {
+	return key, f.putErr
+}
+func (f *fakeDatastore) Get(ctx context.Context, key *datastore.Key, dst interface{}) error {
+	if f.getErr != nil {
+		return f.getErr
+	}
+
+	if f.keys != nil {
+		if entry, exists := f.keys[key.Name]; exists {
+			apiKey := dst.(*APIKey)
+			*apiKey = *entry.entity
+			key.Parent = entry.parent
+			return nil
+		}
+		return datastore.ErrNoSuchEntity
+	}
+
+	return f.getErr
+}
+
+func (f *fakeDatastore) GetAll(ctx context.Context, q *datastore.Query, dst interface{}) ([]*datastore.Key, error) {
+	return nil, f.getErr
+}
+
+func TestDatastoreOrgManager_ValidateKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		ds      *fakeDatastore
+		wantOrg string
+		wantErr error
+	}{
+		{
+			name: "success",
+			key:  "valid-key",
+			ds: &fakeDatastore{
+				keys: map[string]struct {
+					entity *APIKey
+					parent *datastore.Key
+				}{
+					"valid-key": {
+						entity: &APIKey{CreatedAt: time.Now()},
+						parent: datastore.NameKey(OrgKind, "test-org", nil),
+					},
+				},
+			},
+			wantOrg: "test-org",
+		},
+		{
+			name: "error-invalid-key",
+			key:  "invalid-key",
+			ds: &fakeDatastore{
+				keys: map[string]struct {
+					entity *APIKey
+					parent *datastore.Key
+				}{},
+			},
+			wantErr: ErrInvalidKey,
+		},
+		{
+			name: "error-datastore",
+			key:  "valid-key",
+			ds: &fakeDatastore{
+				getErr: errTest,
+			},
+			wantErr: errTest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dm := NewDatastoreManager(tt.ds, "test-project")
+			gotOrg, err := dm.ValidateKey(context.Background(), tt.key)
+
+			if (err != nil && tt.wantErr == nil) ||
+				(err == nil && tt.wantErr != nil) ||
+				(err != nil && tt.wantErr != nil && err.Error() != tt.wantErr.Error()) {
+				t.Errorf("ValidateKey() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if gotOrg != tt.wantOrg {
+				t.Errorf("ValidateKey() = %v, want %v", gotOrg, tt.wantOrg)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -156,7 +156,7 @@ func main() {
 
 	mux.HandleFunc("/autojoin/v0/node/delete", promhttp.InstrumentHandlerDuration(
 		metrics.RequestHandlerDuration.MustCurryWith(prometheus.Labels{"path": "/autojoin/v0/node/delete"}),
-		http.HandlerFunc(s.Delete)))
+		handler.WithAPIKeyValidation(validator, s.Delete)))
 
 	mux.HandleFunc("/autojoin/v0/node/list", promhttp.InstrumentHandlerDuration(
 		metrics.RequestHandlerDuration.MustCurryWith(prometheus.Labels{"path": "/autojoin/v0/node/list"}),

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -72,7 +72,7 @@ paths:
       operationId: "autojoin-v0-node-register"
       parameters:
         - in: query
-          name: key
+          name: api_key
           type: string
           required: true
           description: API key.
@@ -115,6 +115,11 @@ paths:
       operationId: "autojoin-v0-node-delete"
       parameters:
         - in: query
+          name: api_key
+          type: string
+          required: true
+          description: API key.
+        - in: query
           name: hostname
           type: string
           required: true
@@ -124,8 +129,6 @@ paths:
       responses:
         "200":
           description: Deletion was successful.
-      security:
-        - api_key: []
       tags:
         - public
   "/autojoin/v0/node/list":
@@ -147,17 +150,6 @@ paths:
           description: List was successful.
       tags:
         - public
-
-securityDefinitions:
-  # This section configures basic authentication with an API key.
-  # Paths configured with api_key security require an API key for all requests.
-  api_key:
-    type: "apiKey"
-    description: |-
-      An API key for your organization, restricted to the Autojoin API. API keys
-      are allocated by M-Lab for use by a registered organization.
-    name: "key"
-    in: "query"
 
 tags:
   - name: public

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -22,11 +22,11 @@ info:
 host: "autojoin-dot-{{PROJECT}}.appspot.com"
 
 consumes:
-- "application/json"
+  - "application/json"
 produces:
-- "application/json"
+  - "application/json"
 schemes:
-- "https"
+  - "https"
 
 paths:
   # DOES NOT require an API key.
@@ -56,7 +56,7 @@ paths:
       produces:
         - "application/json"
       responses:
-        '200':
+        "200":
           description: Registration was successful.
       tags:
         - public
@@ -72,16 +72,15 @@ paths:
       operationId: "autojoin-v0-node-register"
       parameters:
         - in: query
+          name: key
+          type: string
+          required: true
+          description: API key.
+        - in: query
           name: service
           type: string
           required: true
           description: Service name.
-        - in: query
-          name: organization
-          type: string
-          required: true
-          description: Organization name. Must be the name of a previously registered
-            organization.
         - in: query
           name: iata
           type: string
@@ -91,7 +90,8 @@ paths:
           name: ipv4
           type: string
           required: false
-          description: IPv4 service address. If not provided, the client origin IP is
+          description:
+            IPv4 service address. If not provided, the client origin IP is
             used. If request originates from an IPv6 address, and the ipv4
             parameter is not provided, registration will fail.
         - in: query
@@ -102,10 +102,8 @@ paths:
       produces:
         - "application/json"
       responses:
-        '200':
+        "200":
           description: Registration was successful.
-      security:
-        - api_key: []
       tags:
         - public
   "/autojoin/v0/node/delete":
@@ -124,7 +122,7 @@ paths:
       produces:
         - "application/json"
       responses:
-        '200':
+        "200":
           description: Deletion was successful.
       security:
         - api_key: []
@@ -145,11 +143,10 @@ paths:
       produces:
         - "application/json"
       responses:
-        '200':
+        "200":
           description: List was successful.
       tags:
         - public
-
 
 securityDefinitions:
   # This section configures basic authentication with an API key.


### PR DESCRIPTION
Following #63, this PR updates the Autojoin API to
1. Use Datastore to check if a key is valid
2. Retrieve the organization name from Datastore as well

This makes it impossible to call the /register endpoint with an organization name different than the one we created the API key for.

At the same time, it disables the `securityDefinition` in openapi.yaml so that GAE's own proxy doesn't intercept and try to validate the `api_key` parameter.

Note: Before deployment, API keys from Google Cloud API need to be manually imported to Datastore so that the register tool for existing host-managed deployments keeps working without interruption.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/64)
<!-- Reviewable:end -->
