### PR TITLE
Enforce minimum client version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 # Build stage.
 FROM golang:1.22-alpine as builder
+RUN apk add --no-cache git
 WORKDIR /go/src/m-lab/autojoin
 COPY . .
 RUN go mod download
-
-RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /go/bin/register ./cmd/register
+RUN GIT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0") && \
+    CGO_ENABLED=0 go build -ldflags="-s -w -X main.Version=${GIT_TAG}" -o /go/bin/register ./cmd/register
 
 # Run stage.
 FROM alpine:3.20

--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -32,10 +32,10 @@ const (
 	hostnameFilename       = "hostname"
 )
 
-// Replaced by the linker with the current version at build time.
-var Version = "0.0.0"
-
 var (
+	// Replaced by the linker with the current version at build time.
+	Version = "0.0.0"
+
 	endpoint    = flag.String("endpoint", registerEndpoint, "Endpoint of the autojoin service")
 	apiKey      = flag.String("key", "", "API key for the autojoin service")
 	service     = flag.String("service", "ndt", "Service name to register with the autojoin service")

--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -32,6 +32,9 @@ const (
 	hostnameFilename       = "hostname"
 )
 
+// Replaced by the linker with the current version at build time.
+var Version = "0.0.0"
+
 var (
 	endpoint    = flag.String("endpoint", registerEndpoint, "Endpoint of the autojoin service")
 	apiKey      = flag.String("key", "", "API key for the autojoin service")
@@ -131,6 +134,8 @@ func register() {
 	q.Add("type", *machineType)
 	q.Add("uplink", *uplink)
 	q.Add("probability", siteProb.Value)
+	q.Add("version", Version)
+
 	for _, port := range ports {
 		q.Add("ports", port)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,14 @@
 module github.com/m-lab/autojoin
 
-go 1.20
+go 1.21
+
+toolchain go1.22.2
 
 require (
 	cloud.google.com/go/apikeys v1.1.12
 	cloud.google.com/go/datastore v1.17.1
 	cloud.google.com/go/secretmanager v1.13.5
+	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/go-test/deep v1.1.1
 	github.com/gomodule/redigo v1.8.8
 	github.com/googleapis/gax-go v1.0.3

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/m-lab/autojoin
 
 go 1.21
 
-toolchain go1.22.2
-
 require (
 	cloud.google.com/go/apikeys v1.1.12
 	cloud.google.com/go/datastore v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
+github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
@@ -151,6 +153,7 @@ github.com/go-test/deep v1.0.6/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gocarina/gocsv v0.0.0-20210408192840-02d7211d929d h1:r3mStZSyjKhEcgbJ5xtv7kT5PZw/tDiFBTMgQx2qsXE=
+github.com/gocarina/gocsv v0.0.0-20210408192840-02d7211d929d/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -206,6 +209,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
@@ -214,6 +218,7 @@ github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIG
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.2.1/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/martian/v3 v3.3.3 h1:DIhPTQrbPkgs2yJYdXU/eNACCG5DVQjySNRNlflZ9Fc=
+github.com/google/martian/v3 v3.3.3/go.mod h1:iEPrYcgCF7jA9OtScMFQyAlZZ4YXTKEtJ1E6RWzmBA0=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
@@ -249,6 +254,7 @@ github.com/googleapis/google-cloud-go-testing v0.0.0-20210719221736-1c9a4c676720
 github.com/googleapis/google-cloud-go-testing v0.0.0-20210719221736-1c9a4c676720/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -346,6 +352,7 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/rafaeljusto/redigomock v2.4.0+incompatible h1:d7uo5MVINMxnRr20MxbgDkmZ8QRfevjOVgEa4n0OZyY=
+github.com/rafaeljusto/redigomock v2.4.0+incompatible/go.mod h1:JaY6n2sDr+z2WTsXkOmNRUfDy6FN0L6Nk7x06ndm4tY=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -371,6 +378,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -394,6 +402,7 @@ go.opentelemetry.io/otel v1.24.0/go.mod h1:W7b9Ozg4nkF5tWI5zsXkaKKDjdVjpD4oAt9Qi
 go.opentelemetry.io/otel/metric v1.24.0 h1:6EhoGWWK28x1fbpA4tYTOWBkPefTDQnb8WSGXlc88kI=
 go.opentelemetry.io/otel/metric v1.24.0/go.mod h1:VYhLe1rFfxuTXLgj4CBiyz+9WYBA8pNGJgDcSFRKBco=
 go.opentelemetry.io/otel/sdk v1.24.0 h1:YMPPDNymmQN3ZgczicBY3B6sf9n62Dlj9pWD3ucgoDw=
+go.opentelemetry.io/otel/sdk v1.24.0/go.mod h1:KVrIYw6tEubO9E96HQpcmpTKDVn9gdv35HoYiQWGDFg=
 go.opentelemetry.io/otel/trace v1.24.0 h1:CsKnnL4dUAr/0llH9FKuc698G04IrpWV0MQA/Y1YELI=
 go.opentelemetry.io/otel/trace v1.24.0/go.mod h1:HPc3Xr/cOApsBI154IU0OI0HJexz+aw5uPdbs3UCjNU=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
@@ -661,6 +670,7 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 h1:+cNy6SZtPcJQH3LJVLOSmiC7MMxXNOb3PU/VUEz+EhU=
+golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -22,6 +22,8 @@ import (
 	"google.golang.org/api/dns/v1"
 )
 
+const defaultMinVersion = "v0.0.0"
+
 type fakeIataFinder struct {
 	iata      string
 	lookupErr error
@@ -241,7 +243,7 @@ func TestServer_Lookup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewServer("mlab-sandbox", tt.iata, tt.maxmind, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil)
+			s := NewServer("mlab-sandbox", tt.iata, tt.maxmind, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil, "0.0.0")
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/autojoin/v0/lookup"+tt.request, nil)
 			for key, value := range tt.headers {
@@ -263,7 +265,7 @@ func TestServer_Lookup(t *testing.T) {
 func TestServer_Reload(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		f := &fakeIataFinder{}
-		s := NewServer("mlab-sandbox", f, &fakeMaxmind{}, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil)
+		s := NewServer("mlab-sandbox", f, &fakeMaxmind{}, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil, "0.0.0")
 		s.Reload(context.Background())
 		if f.loads != 1 {
 			t.Errorf("Reload failed to call iata loader")
@@ -273,7 +275,7 @@ func TestServer_Reload(t *testing.T) {
 
 func TestServer_LiveAndReady(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		s := NewServer("mlab-sandbox", &fakeIataFinder{}, &fakeMaxmind{}, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil)
+		s := NewServer("mlab-sandbox", &fakeIataFinder{}, &fakeMaxmind{}, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil, "0.0.0")
 		rw := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		s.Live(rw, req)
@@ -328,17 +330,18 @@ func TestServer_Register(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		Iata     IataFinder
-		Maxmind  MaxmindFinder
-		ASN      ASNFinder
-		DNS      dnsiface.Service
-		Tracker  DNSTracker
-		sm       ServiceAccountSecretManager
-		params   string
-		org      string
-		wantName string
-		wantCode int
+		name       string
+		Iata       IataFinder
+		Maxmind    MaxmindFinder
+		ASN        ASNFinder
+		DNS        dnsiface.Service
+		Tracker    DNSTracker
+		sm         ServiceAccountSecretManager
+		params     string
+		org        string
+		minVersion string
+		wantName   string
+		wantCode   int
 	}{
 		{
 			name:    "success",
@@ -352,8 +355,9 @@ func TestServer_Register(t *testing.T) {
 			sm: &fakeSecretManager{
 				key: "fake key data",
 			},
-			wantName: "foo-lga12345-c0a80001.bar.sandbox.measurement-lab.org",
-			wantCode: http.StatusOK,
+			minVersion: defaultMinVersion,
+			wantName:   "foo-lga12345-c0a80001.bar.sandbox.measurement-lab.org",
+			wantCode:   http.StatusOK,
 		},
 		{
 			name:    "success-probability-invalid-ports-invalid",
@@ -367,57 +371,66 @@ func TestServer_Register(t *testing.T) {
 			sm: &fakeSecretManager{
 				key: "fake key data",
 			},
-			wantName: "foo-lga12345-c0a80001.bar.sandbox.measurement-lab.org",
-			wantCode: http.StatusOK,
+			minVersion: defaultMinVersion,
+			wantName:   "foo-lga12345-c0a80001.bar.sandbox.measurement-lab.org",
+			wantCode:   http.StatusOK,
 		},
 		{
-			name:     "error-service-empty",
-			params:   "?service=",
-			wantCode: http.StatusBadRequest,
+			name:       "error-service-empty",
+			params:     "?service=",
+			minVersion: defaultMinVersion,
+			wantCode:   http.StatusBadRequest,
 		},
 		{
-			name:     "error-service-too-long",
-			params:   "?service=abcdefghijklm",
-			wantCode: http.StatusBadRequest,
+			name:       "error-service-too-long",
+			params:     "?service=abcdefghijklm",
+			minVersion: defaultMinVersion,
+			wantCode:   http.StatusBadRequest,
 		},
 		{
-			name:     "error-bad-type",
-			params:   "?service=foo&iata=lga&ipv4=192.168.0.1&probability=0.5&ports=9990&type=dell&uplink=50g",
-			org:      "bar",
-			wantCode: http.StatusBadRequest,
+			name:       "error-bad-type",
+			params:     "?service=foo&iata=lga&ipv4=192.168.0.1&probability=0.5&ports=9990&type=dell&uplink=50g",
+			org:        "bar",
+			minVersion: defaultMinVersion,
+			wantCode:   http.StatusBadRequest,
 		},
 		{
-			name:     "error-bad-uplink",
-			params:   "?service=foo&iata=lga&ipv4=192.168.0.1&probability=0.5&ports=9990&type=virtual&uplink=10",
-			org:      "bar",
-			wantCode: http.StatusBadRequest,
+			name:       "error-bad-uplink",
+			params:     "?service=foo&iata=lga&ipv4=192.168.0.1&probability=0.5&ports=9990&type=virtual&uplink=10",
+			org:        "bar",
+			minVersion: defaultMinVersion,
+			wantCode:   http.StatusBadRequest,
 		},
 		{
-			name:     "error-bad-ip",
-			params:   "?service=foo&ipv4=-BAD-IP-",
-			org:      "bar",
-			wantCode: http.StatusBadRequest,
+			name:       "error-bad-ip",
+			params:     "?service=foo&ipv4=-BAD-IP-",
+			org:        "bar",
+			minVersion: defaultMinVersion,
+			wantCode:   http.StatusBadRequest,
 		},
 		{
-			name:     "error-invalid-iata",
-			params:   "?service=foo&ipv4=192.168.0.1&iata=-invalid-",
-			org:      "bar",
-			wantCode: http.StatusBadRequest,
+			name:       "error-invalid-iata",
+			params:     "?service=foo&ipv4=192.168.0.1&iata=-invalid-",
+			org:        "bar",
+			minVersion: defaultMinVersion,
+			wantCode:   http.StatusBadRequest,
 		},
 		{
-			name:     "error-bad-iata-find",
-			Iata:     &fakeIataFinder{findErr: errors.New("find err")},
-			params:   "?service=foo&ipv4=192.168.0.1&iata=123&type=physical&uplink=20g",
-			org:      "bar",
-			wantCode: http.StatusInternalServerError,
+			name:       "error-bad-iata-find",
+			Iata:       &fakeIataFinder{findErr: errors.New("find err")},
+			params:     "?service=foo&ipv4=192.168.0.1&iata=123&type=physical&uplink=20g",
+			org:        "bar",
+			minVersion: defaultMinVersion,
+			wantCode:   http.StatusInternalServerError,
 		},
 		{
-			name:     "error-bad-maxmind-city",
-			Iata:     &fakeIataFinder{findRow: iata.Row{}},
-			Maxmind:  &fakeMaxmind{err: errors.New("fake maxmind error")},
-			params:   "?service=foo&ipv4=192.168.0.1&iata=abc&type=virtual&uplink=1000g",
-			org:      "bar",
-			wantCode: http.StatusInternalServerError,
+			name:       "error-bad-maxmind-city",
+			Iata:       &fakeIataFinder{findRow: iata.Row{}},
+			Maxmind:    &fakeMaxmind{err: errors.New("fake maxmind error")},
+			params:     "?service=foo&ipv4=192.168.0.1&iata=abc&type=virtual&uplink=1000g",
+			org:        "bar",
+			minVersion: defaultMinVersion,
+			wantCode:   http.StatusInternalServerError,
 		},
 		{
 			name:    "error-loading-key",
@@ -430,7 +443,8 @@ func TestServer_Register(t *testing.T) {
 			sm: &fakeSecretManager{
 				err: fmt.Errorf("fake key load error"),
 			},
-			wantCode: http.StatusInternalServerError,
+			minVersion: defaultMinVersion,
+			wantCode:   http.StatusInternalServerError,
 		},
 		{
 			name:    "error-registration",
@@ -443,7 +457,8 @@ func TestServer_Register(t *testing.T) {
 			sm: &fakeSecretManager{
 				key: "fake key data",
 			},
-			wantCode: http.StatusInternalServerError,
+			minVersion: defaultMinVersion,
+			wantCode:   http.StatusInternalServerError,
 		},
 		{
 			name:    "error-tracker-update-error",
@@ -457,14 +472,108 @@ func TestServer_Register(t *testing.T) {
 			sm: &fakeSecretManager{
 				key: "fake key data",
 			},
-			wantName: "foo-lga12345-c0a80001.bar.sandbox.measurement-lab.org",
-			wantCode: http.StatusInternalServerError,
+			minVersion: defaultMinVersion,
+			wantName:   "foo-lga12345-c0a80001.bar.sandbox.measurement-lab.org",
+			wantCode:   http.StatusInternalServerError,
+		},
+		{
+			name:    "success-with-version",
+			params:  "?service=foo&iata=lga&ipv4=192.168.0.1&probability=1.0&ports=9990&type=physical&uplink=10g&version=1.0.0",
+			org:     "bar",
+			Iata:    iataFinder,
+			Maxmind: maxmind,
+			ASN:     fakeASN,
+			DNS:     &fakeDNS{},
+			Tracker: &fakeStatusTracker{},
+			sm: &fakeSecretManager{
+				key: "fake key data",
+			},
+			minVersion: "1.0.0",
+			wantName:   "foo-lga12345-c0a80001.bar.sandbox.measurement-lab.org",
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:    "success-no-version",
+			params:  "?service=foo&iata=lga&ipv4=192.168.0.1&probability=1.0&ports=9990&type=physical&uplink=10g",
+			org:     "bar",
+			Iata:    iataFinder,
+			Maxmind: maxmind,
+			ASN:     fakeASN,
+			DNS:     &fakeDNS{},
+			Tracker: &fakeStatusTracker{},
+			sm: &fakeSecretManager{
+				key: "fake key data",
+			},
+			minVersion: "0.0.0",
+			wantName:   "foo-lga12345-c0a80001.bar.sandbox.measurement-lab.org",
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:    "success-newer-version",
+			params:  "?service=foo&iata=lga&ipv4=192.168.0.1&probability=1.0&ports=9990&type=physical&uplink=10g&version=2.0.0",
+			org:     "bar",
+			Iata:    iataFinder,
+			Maxmind: maxmind,
+			ASN:     fakeASN,
+			DNS:     &fakeDNS{},
+			Tracker: &fakeStatusTracker{},
+			sm: &fakeSecretManager{
+				key: "fake key data",
+			},
+			minVersion: "1.0.0",
+			wantName:   "foo-lga12345-c0a80001.bar.sandbox.measurement-lab.org",
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:    "error-invalid-version-format",
+			params:  "?service=foo&iata=lga&ipv4=192.168.0.1&type=physical&uplink=10g&version=not.valid.version",
+			org:     "bar",
+			Iata:    iataFinder,
+			Maxmind: maxmind,
+			ASN:     fakeASN,
+			DNS:     &fakeDNS{},
+			Tracker: &fakeStatusTracker{},
+			sm: &fakeSecretManager{
+				key: "fake key data",
+			},
+			minVersion: "1.0.0",
+			wantCode:   http.StatusBadRequest,
+		},
+		{
+			name:    "error-version-too-old",
+			params:  "?service=foo&iata=lga&ipv4=192.168.0.1&type=physical&uplink=10g&version=0.9.0",
+			org:     "bar",
+			Iata:    iataFinder,
+			Maxmind: maxmind,
+			ASN:     fakeASN,
+			DNS:     &fakeDNS{},
+			Tracker: &fakeStatusTracker{},
+			sm: &fakeSecretManager{
+				key: "fake key data",
+			},
+			minVersion: "1.0.0",
+			wantCode:   http.StatusForbidden,
+		},
+		{
+			name:    "error-no-version-when-minimum-required",
+			params:  "?service=foo&iata=lga&ipv4=192.168.0.1&type=physical&uplink=10g",
+			org:     "bar",
+			Iata:    iataFinder,
+			Maxmind: maxmind,
+			ASN:     fakeASN,
+			DNS:     &fakeDNS{},
+			Tracker: &fakeStatusTracker{},
+			sm: &fakeSecretManager{
+				key: "fake key data",
+			},
+			minVersion: "1.0.0",
+			wantCode:   http.StatusForbidden,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewServer("mlab-sandbox", tt.Iata, tt.Maxmind, tt.ASN, tt.DNS, tt.Tracker, tt.sm)
+			s := NewServer("mlab-sandbox", tt.Iata, tt.Maxmind, tt.ASN, tt.DNS, tt.Tracker, tt.sm, tt.minVersion)
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/autojoin/v0/node/register"+tt.params, nil)
 
@@ -550,7 +659,7 @@ func TestServer_Delete(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewServer("mlab-sandbox", nil, nil, nil, tt.DNS, tt.Tracker, nil)
+			s := NewServer("mlab-sandbox", nil, nil, nil, tt.DNS, tt.Tracker, nil, "0.0.0")
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/autojoin/v0/node/delete"+tt.qs, nil)
 			s.Delete(rw, req)
@@ -654,7 +763,7 @@ func TestServer_List(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewServer("mlab-sandbox", nil, nil, nil, nil, tt.lister, nil)
+			s := NewServer("mlab-sandbox", nil, nil, nil, nil, tt.lister, nil, "0.0.0")
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/autojoin/v0/node/list"+tt.params, nil)
 

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -243,7 +243,7 @@ func TestServer_Lookup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewServer("mlab-sandbox", tt.iata, tt.maxmind, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil, "0.0.0")
+			s := NewServer("mlab-sandbox", tt.iata, tt.maxmind, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil, defaultMinVersion)
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/autojoin/v0/lookup"+tt.request, nil)
 			for key, value := range tt.headers {
@@ -265,7 +265,7 @@ func TestServer_Lookup(t *testing.T) {
 func TestServer_Reload(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		f := &fakeIataFinder{}
-		s := NewServer("mlab-sandbox", f, &fakeMaxmind{}, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil, "0.0.0")
+		s := NewServer("mlab-sandbox", f, &fakeMaxmind{}, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil, defaultMinVersion)
 		s.Reload(context.Background())
 		if f.loads != 1 {
 			t.Errorf("Reload failed to call iata loader")
@@ -275,7 +275,7 @@ func TestServer_Reload(t *testing.T) {
 
 func TestServer_LiveAndReady(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		s := NewServer("mlab-sandbox", &fakeIataFinder{}, &fakeMaxmind{}, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil, "0.0.0")
+		s := NewServer("mlab-sandbox", &fakeIataFinder{}, &fakeMaxmind{}, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil, defaultMinVersion)
 		rw := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		s.Live(rw, req)
@@ -504,7 +504,7 @@ func TestServer_Register(t *testing.T) {
 			sm: &fakeSecretManager{
 				key: "fake key data",
 			},
-			minVersion: "0.0.0",
+			minVersion: defaultMinVersion,
 			wantName:   "foo-lga12345-c0a80001.bar.sandbox.measurement-lab.org",
 			wantCode:   http.StatusOK,
 		},
@@ -659,7 +659,7 @@ func TestServer_Delete(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewServer("mlab-sandbox", nil, nil, nil, tt.DNS, tt.Tracker, nil, "0.0.0")
+			s := NewServer("mlab-sandbox", nil, nil, nil, tt.DNS, tt.Tracker, nil, defaultMinVersion)
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/autojoin/v0/node/delete"+tt.qs, nil)
 			s.Delete(rw, req)
@@ -763,7 +763,7 @@ func TestServer_List(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewServer("mlab-sandbox", nil, nil, nil, nil, tt.lister, nil, "0.0.0")
+			s := NewServer("mlab-sandbox", nil, nil, nil, nil, tt.lister, nil, defaultMinVersion)
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/autojoin/v0/node/list"+tt.params, nil)
 

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ var (
 	listenPort   string
 	project      string
 	redisAddr    string
+	minVersion   string
 	iataSrc      = flagx.MustNewURL("https://raw.githubusercontent.com/ip2location/ip2location-iata-icao/1.0.21/iata-icao.csv")
 	maxmindSrc   = flagx.URL{}
 	routeviewSrc = flagx.URL{}
@@ -47,6 +48,7 @@ func init() {
 	// PORT and GOOGLE_CLOUD_PROJECT are part of the default App Engine environment.
 	flag.StringVar(&listenPort, "port", "8080", "AppEngine port environment variable")
 	flag.StringVar(&project, "google-cloud-project", "", "AppEngine project environment variable")
+	flag.StringVar(&minVersion, "min-version", "0.0.0", "Minimum version of the client to accept")
 	flag.Var(&iataSrc, "iata-url", "URL to IATA dataset")
 	flag.Var(&maxmindSrc, "maxmind-url", "URL of a Maxmind GeoIP dataset, e.g. gs://bucket/file or file:./relativepath/file")
 	flag.Var(&routeviewSrc, "routeview-v4.url", "URL of an ip2prefix routeview IPv4 dataset, e.g. gs://bucket/file and file:./relativepath/file")
@@ -120,7 +122,7 @@ func main() {
 	validator := adminx.NewDatastoreManager(ds, project)
 
 	// Create server.
-	s := handler.NewServer(project, i, mm, asn, d, gc, sm)
+	s := handler.NewServer(project, i, mm, asn, d, gc, sm, minVersion)
 	go func() {
 		// Load once.
 		s.Iata.Load(mainCtx)


### PR DESCRIPTION
This change makes the `/register` endpoint enforce a minimum supported client version and rejects requests that are from old clients. Also, updates the register client to provide a version number.

- If `-min-version` was not provided, it's set to `0.0.0` and the check is effectively disabled
- If `-min-version` was provided and the client specifies a version, the client version is compared with the minimum accepted version according to the semantic versioning rules
- If `-min-version` was provided and the client does not provide a version, the client version is assumed to be `0.0.0` and compared accordingly

This ensures that during the transition existing register clients will keep working. Once we are sure all site hosts are using an up-to-date version of the register client, we can set `-min-version`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/66)
<!-- Reviewable:end -->
