### PR TITLE
Adds probability multiplier to Organization entities

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -299,7 +299,7 @@ func (s *Server) Register(rw http.ResponseWriter, req *http.Request) {
 	}
 	// Assign the probability by multiplying the org multiplier with the
 	// probability requested by the client.
-	param.Probability = getProbability(req, orgMultiplier)
+	param.Probability = getProbability(req) * orgMultiplier
 	r := register.CreateRegisterResponse(param)
 
 	key, err := s.sm.LoadOrCreateKey(req.Context(), param.Org)
@@ -627,16 +627,16 @@ func getClientIP(req *http.Request) string {
 	return hip
 }
 
-func getProbability(req *http.Request, orgMultiplier float64) float64 {
+func getProbability(req *http.Request) float64 {
 	prob := req.URL.Query().Get("probability")
 	if prob == "" {
-		return 1.0 * orgMultiplier
+		return 1.0
 	}
 	p, err := strconv.ParseFloat(prob, 64)
 	if err != nil {
-		return 1.0 * orgMultiplier
+		return 1.0
 	}
-	return p * orgMultiplier
+	return p
 }
 
 func getPorts(req *http.Request) []string {

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -263,7 +263,7 @@ func TestServer_Lookup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewServer("mlab-sandbox", tt.iata, tt.maxmind, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil, &fakeDatastoreOrgManager{}, defaultMinVersion)
+			s := NewServer("mlab-sandbox", tt.iata, tt.maxmind, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil, nil, defaultMinVersion)
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/autojoin/v0/lookup"+tt.request, nil)
 			for key, value := range tt.headers {
@@ -285,7 +285,7 @@ func TestServer_Lookup(t *testing.T) {
 func TestServer_Reload(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		f := &fakeIataFinder{}
-		s := NewServer("mlab-sandbox", f, &fakeMaxmind{}, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil, &fakeDatastoreOrgManager{}, defaultMinVersion)
+		s := NewServer("mlab-sandbox", f, &fakeMaxmind{}, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil, nil, defaultMinVersion)
 		s.Reload(context.Background())
 		if f.loads != 1 {
 			t.Errorf("Reload failed to call iata loader")
@@ -295,7 +295,7 @@ func TestServer_Reload(t *testing.T) {
 
 func TestServer_LiveAndReady(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		s := NewServer("mlab-sandbox", &fakeIataFinder{}, &fakeMaxmind{}, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil, &fakeDatastoreOrgManager{}, defaultMinVersion)
+		s := NewServer("mlab-sandbox", &fakeIataFinder{}, &fakeMaxmind{}, &fakeAsn{}, &fakeDNS{}, &fakeStatusTracker{}, nil, nil, defaultMinVersion)
 		rw := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		s.Live(rw, req)
@@ -679,7 +679,7 @@ func TestServer_Delete(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewServer("mlab-sandbox", nil, nil, nil, tt.DNS, tt.Tracker, nil, &fakeDatastoreOrgManager{}, defaultMinVersion)
+			s := NewServer("mlab-sandbox", nil, nil, nil, tt.DNS, tt.Tracker, nil, nil, defaultMinVersion)
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/autojoin/v0/node/delete"+tt.qs, nil)
 			s.Delete(rw, req)
@@ -783,7 +783,7 @@ func TestServer_List(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewServer("mlab-sandbox", nil, nil, nil, nil, tt.lister, nil, &fakeDatastoreOrgManager{}, defaultMinVersion)
+			s := NewServer("mlab-sandbox", nil, nil, nil, nil, tt.lister, nil, nil, defaultMinVersion)
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/autojoin/v0/node/list"+tt.params, nil)
 

--- a/main.go
+++ b/main.go
@@ -118,11 +118,10 @@ func main() {
 	ds, err := datastore.NewClient(mainCtx, project)
 	rtx.Must(err, "failed to create datastore client")
 	defer ds.Close()
-	// Use Datastore manager as validator.
-	validator := adminx.NewDatastoreManager(ds, project)
+	dsm := adminx.NewDatastoreManager(ds, project)
 
 	// Create server.
-	s := handler.NewServer(project, i, mm, asn, d, gc, sm, minVersion)
+	s := handler.NewServer(project, i, mm, asn, d, gc, sm, dsm, minVersion)
 	go func() {
 		// Load once.
 		s.Iata.Load(mainCtx)
@@ -154,11 +153,11 @@ func main() {
 	// Nodes register on start up.
 	mux.HandleFunc("/autojoin/v0/node/register", promhttp.InstrumentHandlerDuration(
 		metrics.RequestHandlerDuration.MustCurryWith(prometheus.Labels{"path": "/autojoin/v0/node/register"}),
-		handler.WithAPIKeyValidation(validator, s.Register)))
+		handler.WithAPIKeyValidation(dsm, s.Register)))
 
 	mux.HandleFunc("/autojoin/v0/node/delete", promhttp.InstrumentHandlerDuration(
 		metrics.RequestHandlerDuration.MustCurryWith(prometheus.Labels{"path": "/autojoin/v0/node/delete"}),
-		handler.WithAPIKeyValidation(validator, s.Delete)))
+		handler.WithAPIKeyValidation(dsm, s.Delete)))
 
 	mux.HandleFunc("/autojoin/v0/node/list", promhttp.InstrumentHandlerDuration(
 		metrics.RequestHandlerDuration.MustCurryWith(prometheus.Labels{"path": "/autojoin/v0/node/list"}),


### PR DESCRIPTION
This PR adds a new `probability_multiplier` field to each `Organization` entity in Datastore. This value is multiplied by the `probability` querystring parameter during a node registration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/67)
<!-- Reviewable:end -->
