### PR TITLE
Fix probability calculation when the field does not exist in DS

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -294,8 +294,8 @@ func (s *Server) Register(rw http.ResponseWriter, req *http.Request) {
 	// Get the organization probability multiplier.
 	orgEntity, err := s.dsm.GetOrganization(req.Context(), param.Org)
 	orgMultiplier := 1.0
-	if err == nil && orgEntity != nil {
-		orgMultiplier = orgEntity.ProbabilityMultiplier
+	if err == nil && orgEntity != nil && orgEntity.ProbabilityMultiplier != nil {
+		orgMultiplier = *orgEntity.ProbabilityMultiplier
 	}
 	// Assign the probability by multiplying the org multiplier with the
 	// probability requested by the client.

--- a/internal/adminx/datastore.go
+++ b/internal/adminx/datastore.go
@@ -31,7 +31,7 @@ type Organization struct {
 	Name                  string    `datastore:"name"`
 	Email                 string    `datastore:"email"`
 	CreatedAt             time.Time `datastore:"created_at"`
-	ProbabilityMultiplier float64   `datastore:"probability_multiplier"`
+	ProbabilityMultiplier *float64  `datastore:"probability_multiplier"`
 }
 
 // APIKey represents a Datastore entity for storing API key metadata.
@@ -60,12 +60,12 @@ func NewDatastoreManager(client DatastoreClient, project string) *DatastoreOrgMa
 func (d *DatastoreOrgManager) CreateOrganization(ctx context.Context, name, email string) error {
 	key := datastore.NameKey(OrgKind, name, nil)
 	key.Namespace = d.namespace
-
+	prob := 1.0
 	org := &Organization{
 		Name:                  name,
 		Email:                 email,
 		CreatedAt:             time.Now().UTC(),
-		ProbabilityMultiplier: 1.0,
+		ProbabilityMultiplier: &prob,
 	}
 
 	_, err := d.client.Put(ctx, key, org)


### PR DESCRIPTION
The previous code treated a nonexistent `ProbabilityMultiplier` field as 0, effectively setting all probabilities to 0 for orgs that had been created before we introduced this new field. This change makes `ProbabilityMultiplier` a pointer, allowing the datastore client to leave it as `nil` when the field does not exist in DS, and fixes the logic.