### PR TITLE
WIP: Support JWT authentication for the autojoin API

### DIFF
--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -129,7 +129,7 @@ func register() {
 	token, err := exchangeAPIKeyForJWT(*apiKey, "autojoin")
 	rtx.Must(err, "Failed to exchange API key for JWT")
 
-	// 2. Prepare the register request (no api_key in query).
+	// 2. Prepare the register request.
 	registerURL, err := url.Parse(*endpoint)
 	rtx.Must(err, "Failed to parse autojoin service URL")
 	q := registerURL.Query()

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	cloud.google.com/go/secretmanager v1.13.5
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/go-test/deep v1.1.1
+	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/gomodule/redigo v1.8.8
 	github.com/googleapis/gax-go v1.0.3
 	github.com/googleapis/gax-go/v2 v2.13.0

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,8 @@ github.com/gocarina/gocsv v0.0.0-20210408192840-02d7211d929d h1:r3mStZSyjKhEcgbJ
 github.com/gocarina/gocsv v0.0.0-20210408192840-02d7211d929d/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/handler/validator.go
+++ b/handler/validator.go
@@ -25,10 +25,13 @@ type APIKeyValidator interface {
 
 // WithAPIKeyValidation creates middleware that validates API keys and adds
 // org info to context.
+//
+// Note: This supports the migration to JWT tokens. If a JWT is provided, the
+// organization name is extracted from its claim. Otherwise, the legacy API key
+// is validated in Datastore and the associated organization name is retrieved.
 func WithAPIKeyValidation(validator APIKeyValidator, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// First, check for the Authorization header. If available, just extract
-		// the "org" claim and use it.
+		// First, check for the Authorization header.
 		authHeader := r.Header.Get("Authorization")
 		if strings.HasPrefix(authHeader, "Bearer ") {
 			tokenString := strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer "))

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -39,6 +39,10 @@ securityDefinitions:
     # x-google-audiences are the audiences JWTs are allowed to target.
     # The value should be the backend service name, which is derived from the 'host' field.
     x-google-audiences: "autojoin"
+  legacy_api_key:
+    type: "apiKey"
+    name: "api_key"
+    in: "query"
 
 paths:
   # Requires JWT authentication.
@@ -84,12 +88,8 @@ paths:
       operationId: "autojoin-v0-node-register"
       security:
         - jwks: []
+        - legacy_api_key: []
       parameters:
-        - in: query
-          name: api_key
-          type: string
-          required: true
-          description: API key.
         - in: query
           name: service
           type: string
@@ -129,12 +129,8 @@ paths:
       operationId: "autojoin-v0-node-delete"
       security:
         - jwks: []
+        - legacy_api_key: []
       parameters:
-        - in: query
-          name: api_key
-          type: string
-          required: true
-          description: API key.
         - in: query
           name: hostname
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -28,15 +28,29 @@ produces:
 schemes:
   - "https"
 
+securityDefinitions:
+  jwks:
+    authorizationUrl: "" # Required for swagger 2.0 oauth2, but not used by ESPv2/Apigee
+    flow: "implicit" # Required for swagger 2.0 oauth2, but not used by ESPv2/Apigee
+    type: "oauth2"
+    # x-google-jwks_uri and x-google-issuer identify the service that issues JWTs.
+    x-google-issuer: "token-exchange"
+    x-google-jwks_uri: "https://token-exchange.mlab-sandbox.measurementlab.net/.well-known/jwks"
+    # x-google-audiences are the audiences JWTs are allowed to target.
+    # The value should be the backend service name, which is derived from the 'host' field.
+    x-google-audiences: "autojoin"
+
 paths:
-  # DOES NOT require an API key.
+  # Requires JWT authentication.
   "/autojoin/v0/lookup":
     get:
       description: |-
         Find the nearest IATA location based on user parameters.
 
-        This resource does not require an API key.
+        This resource requires JWT authentication.
       operationId: "autojoin-v0-lookup"
+      security:
+        - jwks: []
       parameters:
         - in: query
           name: country

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -49,8 +49,6 @@ paths:
 
         This resource requires JWT authentication.
       operationId: "autojoin-v0-lookup"
-      security:
-        - jwks: []
       parameters:
         - in: query
           name: country
@@ -84,6 +82,8 @@ paths:
 
         This resource requires an API key.
       operationId: "autojoin-v0-node-register"
+      security:
+        - jwks: []
       parameters:
         - in: query
           name: api_key
@@ -127,6 +127,8 @@ paths:
 
         This resource requires an API key.
       operationId: "autojoin-v0-node-delete"
+      security:
+        - jwks: []
       parameters:
         - in: query
           name: api_key

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -35,7 +35,7 @@ securityDefinitions:
     type: "oauth2"
     # x-google-jwks_uri and x-google-issuer identify the service that issues JWTs.
     x-google-issuer: "token-exchange"
-    x-google-jwks_uri: "https://token-exchange.mlab-sandbox.measurementlab.net/.well-known/jwks"
+    x-google-jwks_uri: "https://token-exchange.mlab-sandbox.measurementlab.net/.well-known/jwks.json"
     # x-google-audiences are the audiences JWTs are allowed to target.
     # The value should be the backend service name, which is derived from the 'host' field.
     x-google-audiences: "autojoin"


### PR DESCRIPTION
This PR updates the autojoin API to support JWT-based authentication while maintaining backward compatibility with API keys. This is part of a broader effort to centralize API key verification through the [token-exchange](https://github.com/m-lab/token-exchange) service.

Clients can now authenticate either via:
  1. **JWT**: Using `Authorization: Bearer <token>` header with a JWT obtained from the token-exchange service
     - In this case, the "org" claim is extracted from the JWT without further verification, as the verification step is done earlier in the stack (by Cloud Endpoints)

  3. **API Key**: Using the `?api_key=<key>` query parameter, maintained for backward compatibility
     - The organization is retrieved from Datastore as before

Things to verify before merging:
- [ ] JWT authentication works with token-exchange service
- [ ] Legacy API key authentication still works
- [ ] Organization in the context is correctly populated in both cases
- [ ] Register client successfully performs token exchange