### PR TITLE
Fix delete endpoint to use JWT authentication

### DIFF
--- a/main.go
+++ b/main.go
@@ -162,7 +162,7 @@ func main() {
 
 	mux.HandleFunc("/autojoin/v0/node/delete", promhttp.InstrumentHandlerDuration(
 		metrics.RequestHandlerDuration.MustCurryWith(prometheus.Labels{"path": "/autojoin/v0/node/delete"}),
-		handler.WithAPIKeyValidation(dsm, s.Delete)))
+		handler.WithJWTValidation(s.Delete)))
 
 	mux.HandleFunc("/autojoin/v0/node/list", promhttp.InstrumentHandlerDuration(
 		metrics.RequestHandlerDuration.MustCurryWith(prometheus.Labels{"path": "/autojoin/v0/node/list"}),


### PR DESCRIPTION
Update delete endpoint from API key validation to JWT validation to match OpenAPI specification security requirements.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/74)
<!-- Reviewable:end -->
