### PR TITLE
Reduces GC_TTL from 14d to 1d

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -35,4 +35,5 @@ env_variables:
   MAXMIND_URL: gs://downloader-{{PROJECT_ID}}/Maxmind/current/GeoLite2-City.tar.gz
   ROUTEVIEW_V4_URL: gs://downloader-{{PROJECT_ID}}/RouteViewIPv4/current/routeview.pfx2as.gz
   REDIS_ADDRESS: {{REDIS_ADDRESS}}
-  GC_TTL: 336h # 14d
+  GC_TTL: 24h
+


### PR DESCRIPTION
The TTL was originally only 3h, but we bumped it up to 14d in anticipation of leveraging the Autojoin system from M-Lab-managed VMs to give us plenty of warning time before a bug might delete all the DNS records for a substantial number of production VMs. However, we never implemented the M-Lab-managed VMs using the Autojoin system.

This commit lowers the GC_TTL down to 1d, which should be plenty, and is in any case 8 times longer than the original 3h setting.

When this value is too high for no useful reason, it causes the Autojoin system to keep a bunch of records around for Autojoin machines that may no longer actually exist, which ends up polluting monitoring and observability.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/77)
<!-- Reviewable:end -->
