### PR TITLE
Ensures that service is compatible with machine

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -448,6 +448,15 @@ func (s *Server) List(rw http.ResponseWriter, req *http.Request) {
 			// Skip hosts that are not part of the given org.
 			continue
 		}
+		// The Autojoin API provides Prometheus with a target list for
+		// blackbox-exporter and script-exporter. When it was first designed,
+		// the intention was that it would _only_ support ndt7, so it was
+		// appropriate to return every single machine as a target for ndt7
+		// monitoring. However, as we contemplate and experiment with creating
+		// BYOS for other experiments, we don't want non-ndt7 target returned
+		// for ndt7 monitoring. This just checks to make sure that the service
+		// parameter of the request to the Autojoin API actually matches the
+		// service embedded in the machine name.
 		if service != "" && !strings.HasPrefix(service, h.Service) {
 			// Skip hosts that are not part of the requested service
 			continue


### PR DESCRIPTION
If the requested service is "ndt7" or "ndt7_client", then the Autojoin API should not return, for example, Wehe servers.

Prometheus (well, gcp-service-discovery) queries the Autojoin API for script-exporter targets for ndt7 e2e testing. The list endpoint should not return machines running experiments that are not compatible with the requested service.

This wasn't necessary before, but we are investigating running experiments other than ndt7 on BYOS machines. Therefore, the Autojoin API should only return ndt BYOS machines for ndt7 e2e testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/78)
<!-- Reviewable:end -->
