### PR TITLE
chore: bump Go runtime to 1.25 in app.yaml

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -4,7 +4,7 @@ service: autojoin
 
 runtime_config:
   operating_system: "ubuntu22"
-  runtime_version: "1.23"
+  runtime_version: "1.25"
 
 endpoints_api_service:
   name: autojoin-dot-{{PROJECT_ID}}.appspot.com


### PR DESCRIPTION
I recently (#83) updated the go version everywhere except in app.yaml. This PR fixes that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/84)
<!-- Reviewable:end -->
