### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,6 @@
 name: coverage
+permissions:
+  contents: read
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/m-lab/autojoin/security/code-scanning/2](https://github.com/m-lab/autojoin/security/code-scanning/2)

To fix the problem, we must explicitly set `permissions` for the workflow or individual jobs, restricting the `GITHUB_TOKEN` to the minimal scopes required. This workflow checks out code, runs `go test`, and sends coverage via `shogo82148/actions-goveralls@v1`. These operations only require read access to repository contents; they do not create or modify issues, PRs, or repository data. Therefore, setting `permissions: contents: read` at the workflow (top) level is an appropriate least‑privilege configuration and will apply to both `coverage` and `finish` jobs.

The best fix without changing functionality is to add a root-level `permissions` block directly under the `name: coverage` line in `.github/workflows/coverage.yml`. This will ensure that, unless a job overrides permissions, both jobs run with `contents: read` and no write scopes. No other code, steps, or actions need modification, and no imports or additional methods are involved, as this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/85)
<!-- Reviewable:end -->
