### PR TITLE
orgadm: add -delete mode to remove all resources for an organization

### DIFF
--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -85,6 +85,9 @@ func (f *fakeDNS) CreateManagedZone(ctx context.Context, project string, zone *d
 func (f *fakeDNS) GetManagedZone(ctx context.Context, project, zoneName string) (*dns.ManagedZone, error) {
 	return nil, nil
 }
+func (f *fakeDNS) DeleteManagedZone(ctx context.Context, project, zoneName string) error {
+	return nil
+}
 
 type fakeStatusTracker struct {
 	updateErr error

--- a/internal/adminx/datastorex.go
+++ b/internal/adminx/datastorex.go
@@ -1,0 +1,103 @@
+package adminx
+
+import (
+	"context"
+	"errors"
+
+	"cloud.google.com/go/datastore"
+	"github.com/m-lab/token-exchange/store"
+)
+
+// datastoreClient defines datastore operations needed by orgadm setup/delete.
+type datastoreClient interface {
+	Put(ctx context.Context, key *datastore.Key, src any) (*datastore.Key, error)
+	Get(ctx context.Context, key *datastore.Key, dst any) error
+	GetAll(ctx context.Context, q *datastore.Query, dst any) ([]*datastore.Key, error)
+	Delete(ctx context.Context, key *datastore.Key) error
+	DeleteMulti(ctx context.Context, keys []*datastore.Key) error
+}
+
+// DatastoreManager wraps token-exchange AutojoinManager and adds delete helpers.
+type DatastoreManager struct {
+	am        *store.AutojoinManager
+	client    datastoreClient
+	namespace string
+}
+
+// NewDatastoreManager creates a DatastoreManager for setup and teardown.
+func NewDatastoreManager(client datastoreClient, project, namespace string) *DatastoreManager {
+	return &DatastoreManager{
+		am:        store.NewAutojoinManager(client, project, namespace),
+		client:    client,
+		namespace: namespace,
+	}
+}
+
+// CreateOrganization creates a new organization entity in datastore.
+func (d *DatastoreManager) CreateOrganization(ctx context.Context, name, email string) error {
+	return d.am.CreateOrganization(ctx, name, email)
+}
+
+// CreateAPIKeyWithValue creates a new API key for org.
+func (d *DatastoreManager) CreateAPIKeyWithValue(ctx context.Context, org, value string) (string, error) {
+	return d.am.CreateAPIKeyWithValue(ctx, org, value)
+}
+
+// GetAPIKeys returns all API keys for org.
+func (d *DatastoreManager) GetAPIKeys(ctx context.Context, org string) ([]string, error) {
+	return d.am.GetAPIKeys(ctx, org)
+}
+
+// DeleteAPIKeys deletes all API key entities under Organization/<org>.
+func (d *DatastoreManager) DeleteAPIKeys(ctx context.Context, org string) error {
+	parent := datastore.NameKey(store.AutojoinOrgKind, org, nil)
+	parent.Namespace = d.namespace
+
+	q := datastore.NewQuery(store.AutojoinAPIKeyKind).
+		Namespace(d.namespace).
+		Ancestor(parent).
+		KeysOnly()
+
+	keys, err := d.client.GetAll(ctx, q, nil)
+	if err != nil {
+		return err
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	err = d.client.DeleteMulti(ctx, keys)
+	if datastoreDeleteNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+// DeleteOrganization deletes Organization/<org>.
+func (d *DatastoreManager) DeleteOrganization(ctx context.Context, org string) error {
+	key := datastore.NameKey(store.AutojoinOrgKind, org, nil)
+	key.Namespace = d.namespace
+	err := d.client.Delete(ctx, key)
+	if errors.Is(err, datastore.ErrNoSuchEntity) {
+		return nil
+	}
+	return err
+}
+
+func datastoreDeleteNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, datastore.ErrNoSuchEntity) {
+		return true
+	}
+	var merr datastore.MultiError
+	if errors.As(err, &merr) {
+		for i := range merr {
+			if merr[i] != nil && !errors.Is(merr[i], datastore.ErrNoSuchEntity) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}

--- a/internal/adminx/datastorex_test.go
+++ b/internal/adminx/datastorex_test.go
@@ -1,0 +1,146 @@
+package adminx
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/datastore"
+	"github.com/m-lab/token-exchange/store"
+)
+
+type fakeDatastoreClient struct {
+	getAllKeys      []*datastore.Key
+	getAllErr       error
+	deleteErr       error
+	deleteMultiErr  error
+	deletedKey      *datastore.Key
+	deletedKeyBatch []*datastore.Key
+}
+
+func (f *fakeDatastoreClient) Put(ctx context.Context, key *datastore.Key, src any) (*datastore.Key, error) {
+	return key, nil
+}
+
+func (f *fakeDatastoreClient) Get(ctx context.Context, key *datastore.Key, dst any) error {
+	return nil
+}
+
+func (f *fakeDatastoreClient) GetAll(ctx context.Context, q *datastore.Query, dst any) ([]*datastore.Key, error) {
+	return f.getAllKeys, f.getAllErr
+}
+
+func (f *fakeDatastoreClient) Delete(ctx context.Context, key *datastore.Key) error {
+	f.deletedKey = key
+	return f.deleteErr
+}
+
+func (f *fakeDatastoreClient) DeleteMulti(ctx context.Context, keys []*datastore.Key) error {
+	f.deletedKeyBatch = append([]*datastore.Key{}, keys...)
+	return f.deleteMultiErr
+}
+
+func TestDatastoreManager_DeleteAPIKeys(t *testing.T) {
+	keys := []*datastore.Key{
+		datastore.NameKey(store.AutojoinAPIKeyKind, "k1", datastore.NameKey(store.AutojoinOrgKind, "foo", nil)),
+		datastore.NameKey(store.AutojoinAPIKeyKind, "k2", datastore.NameKey(store.AutojoinOrgKind, "foo", nil)),
+	}
+
+	tests := []struct {
+		name    string
+		client  *fakeDatastoreClient
+		wantDel int
+		wantErr bool
+	}{
+		{
+			name: "success",
+			client: &fakeDatastoreClient{
+				getAllKeys: keys,
+			},
+			wantDel: 2,
+		},
+		{
+			name: "success-no-keys",
+			client: &fakeDatastoreClient{
+				getAllKeys: nil,
+			},
+			wantDel: 0,
+		},
+		{
+			name: "success-not-found",
+			client: &fakeDatastoreClient{
+				getAllKeys:     keys,
+				deleteMultiErr: datastore.MultiError{datastore.ErrNoSuchEntity, nil},
+			},
+			wantDel: 2,
+		},
+		{
+			name: "error-getall",
+			client: &fakeDatastoreClient{
+				getAllErr: errors.New("getall"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "error-delete-multi",
+			client: &fakeDatastoreClient{
+				getAllKeys:     keys,
+				deleteMultiErr: errors.New("delete-multi"),
+			},
+			wantDel: 2,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dm := NewDatastoreManager(tt.client, "mlab-foo", "platform-credentials")
+			err := dm.DeleteAPIKeys(context.Background(), "foo")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("DatastoreManager.DeleteAPIKeys() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got := len(tt.client.deletedKeyBatch); got != tt.wantDel {
+				t.Fatalf("DatastoreManager.DeleteAPIKeys() deleted = %d, want %d", got, tt.wantDel)
+			}
+		})
+	}
+}
+
+func TestDatastoreManager_DeleteOrganization(t *testing.T) {
+	tests := []struct {
+		name    string
+		client  *fakeDatastoreClient
+		wantErr bool
+	}{
+		{
+			name:   "success",
+			client: &fakeDatastoreClient{},
+		},
+		{
+			name: "success-not-found",
+			client: &fakeDatastoreClient{
+				deleteErr: datastore.ErrNoSuchEntity,
+			},
+		},
+		{
+			name: "error",
+			client: &fakeDatastoreClient{
+				deleteErr: errors.New("delete"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dm := NewDatastoreManager(tt.client, "mlab-foo", "platform-credentials")
+			err := dm.DeleteOrganization(context.Background(), "foo")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("DatastoreManager.DeleteOrganization() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.client.deletedKey == nil {
+				t.Fatalf("DatastoreManager.DeleteOrganization() did not call Delete")
+			}
+		})
+	}
+}

--- a/internal/adminx/iamiface/iam.go
+++ b/internal/adminx/iamiface/iam.go
@@ -27,3 +27,8 @@ func (i *iamImpl) CreateServiceAccount(ctx context.Context, pName string, req *i
 func (i *iamImpl) CreateKey(ctx context.Context, saName string, req *iam.CreateServiceAccountKeyRequest) (*iam.ServiceAccountKey, error) {
 	return i.iamClient.Projects.ServiceAccounts.Keys.Create(saName, req).Context(ctx).Do()
 }
+
+func (i *iamImpl) DeleteServiceAccount(ctx context.Context, saName string) error {
+	_, err := i.iamClient.Projects.ServiceAccounts.Delete(saName).Context(ctx).Do()
+	return err
+}

--- a/internal/adminx/secrets.go
+++ b/internal/adminx/secrets.go
@@ -12,6 +12,7 @@ import (
 type SecretManagerClient interface {
 	GetSecret(ctx context.Context, req *secretmanagerpb.GetSecretRequest, opts ...gax.CallOption) (*secretmanagerpb.Secret, error)
 	CreateSecret(ctx context.Context, req *secretmanagerpb.CreateSecretRequest, opts ...gax.CallOption) (*secretmanagerpb.Secret, error)
+	DeleteSecret(ctx context.Context, req *secretmanagerpb.DeleteSecretRequest, opts ...gax.CallOption) error
 	GetSecretVersion(ctx context.Context, req *secretmanagerpb.GetSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.SecretVersion, error)
 	AddSecretVersion(ctx context.Context, req *secretmanagerpb.AddSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.SecretVersion, error)
 	AccessSecretVersion(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error)
@@ -96,6 +97,18 @@ func (s *SecretManager) LoadOrCreateKey(ctx context.Context, org string) (string
 		return "", err
 	}
 	return key, nil
+}
+
+// DeleteSecret deletes the org secret. NotFound is treated as success.
+func (s *SecretManager) DeleteSecret(ctx context.Context, org string) error {
+	req := &secretmanagerpb.DeleteSecretRequest{
+		Name: s.Namer.GetSecretName(org),
+	}
+	err := s.smc.DeleteSecret(ctx, req)
+	if errIsNotFound(err) {
+		return nil
+	}
+	return err
 }
 
 // StoreKey saves the given key in the org's secret.

--- a/internal/dnsx/dnsiface/dns.go
+++ b/internal/dnsx/dnsiface/dns.go
@@ -12,6 +12,7 @@ type Service interface {
 	ChangeCreate(ctx context.Context, project string, zone string, change *dns.Change) (*dns.Change, error)
 	GetManagedZone(ctx context.Context, project, zoneName string) (*dns.ManagedZone, error)
 	CreateManagedZone(ctx context.Context, project string, z *dns.ManagedZone) (*dns.ManagedZone, error)
+	DeleteManagedZone(ctx context.Context, project, zoneName string) error
 }
 
 // CloudDNSService implements the DNS Service interface.
@@ -42,4 +43,9 @@ func (c *CloudDNSService) GetManagedZone(ctx context.Context, project, zoneName 
 // CreateManagedZone creates the given zone.
 func (c *CloudDNSService) CreateManagedZone(ctx context.Context, project string, zone *dns.ManagedZone) (*dns.ManagedZone, error) {
 	return c.Service.ManagedZones.Create(project, zone).Context(ctx).Do()
+}
+
+// DeleteManagedZone deletes the named managed zone.
+func (c *CloudDNSService) DeleteManagedZone(ctx context.Context, project, zoneName string) error {
+	return c.Service.ManagedZones.Delete(project, zoneName).Context(ctx).Do()
 }

--- a/internal/tracker/gc_test.go
+++ b/internal/tracker/gc_test.go
@@ -30,6 +30,9 @@ func (f *fakeDNS) CreateManagedZone(ctx context.Context, project string, zone *d
 func (f *fakeDNS) GetManagedZone(ctx context.Context, project, zoneName string) (*dns.ManagedZone, error) {
 	return nil, nil
 }
+func (f *fakeDNS) DeleteManagedZone(ctx context.Context, project, zoneName string) error {
+	return nil
+}
 
 type fakeMemorystoreClient[V any] struct {
 	putErr error


### PR DESCRIPTION
## Summary
This implements Issue #96 by adding a **delete mode** to `orgadm`, so operators can remove an org and the resources created by `orgadm` setup in one command.

## What changed

### CLI
- Adds a `-delete` flag to `cmd/orgadm`.
- When `-delete` is set, `orgadm` runs teardown instead of setup.

### Teardown behavior
Implements `Org.Delete(ctx, org)` to remove the setup-created resources in a safe reverse order:

1. Datastore API keys (APIKey children under `Organization/<org>`)
2. Parent-zone DNS NS split RRSet
3. Org managed DNS zone
4. Secret Manager secret
5. Project IAM conditional bindings for the org service account
6. Service account
7. Datastore org entity (`Organization/<org>`)

### IAM cleanup
Removes **only** the bindings created for the org service account by matching `role + member + condition expression`.

Handles both upload variants:
- `roles/storage.objectCreator` (default upload)
- `roles/storage.objectUser` (upload-with-tables)

Also removes the read binding:
- `roles/storage.objectViewer`

Unrelated bindings are preserved.

## Tests
Adds targeted unit tests covering:
- happy-path teardown orchestration
- idempotent rerun with missing resources
- precise IAM removal (remove intended, keep unrelated)
- DNS split missing / zone deletion behavior
- service account delete
- secret delete
- datastore API key + org deletion

## Verification
```sh
go test ./...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autojoin/98)
<!-- Reviewable:end -->
